### PR TITLE
Fix Vercel deployment error by correcting SSR build configuration

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,8 +1,0 @@
-import routes from "/:routes.js";
-import create from "/:create.jsx";
-
-export default {
-  context: import("/:context.js"),
-  routes,
-  create,
-};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "node server.js",
     "build": "npm run build:client && npm run build:server",
     "build:client": "vite build --outDir dist/client --ssrManifest",
-    "build:server": "vite build --outDir dist/server --ssr /index.js",
+    "build:server": "vite build --outDir dist/server --ssr entry-server.jsx",
     "devinstall": "zx ../../devinstall.mjs -- node server.js --dev",
     "lint": "eslint . --ext .js,.jsx --fix"
   },


### PR DESCRIPTION
Fixes #2

This PR resolves the Vercel deployment error where Rollup failed to resolve import "/:routes.js".

## Changes
- Remove problematic `client/index.js` with invalid import paths (`/:routes.js`, `/:context.js`, `/:create.jsx`)
- Update `build:server` script to use `entry-server.jsx` as SSR entry point instead of `/index.js`

The build should now complete successfully on Vercel.

Generated with [Claude Code](https://claude.ai/code)