### PR TITLE
Unify model name to gpt-4o-realtime-preview-2025-06-03

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -42,7 +42,7 @@ export default function App() {
     await pc.setLocalDescription(offer);
 
     const baseUrl = "https://api.openai.com/v1/realtime";
-    const model = "gpt-4o-realtime-preview-2024-12-17";
+    const model = "gpt-4o-realtime-preview-2025-06-03";
     const sdpResponse = await fetch(`${baseUrl}?model=${model}&voice=${selectedVoice}`, {
       method: "POST",
       body: offer.sdp,


### PR DESCRIPTION
Unified model names across the codebase to use `gpt-4o-realtime-preview-2025-06-03` consistently.

## Changes
- Updated `client/components/App.jsx` to use the same model version as `api/token.js`
- Both locations now use `gpt-4o-realtime-preview-2025-06-03` consistently

Fixes #14

Generated with [Claude Code](https://claude.ai/code)