### PR TITLE
Add voice options and instructions settings to main page

### DIFF
--- a/client/components/ToolPanel.jsx
+++ b/client/components/ToolPanel.jsx
@@ -66,23 +66,12 @@ function FunctionCallOutput({ functionCallOutput }) {
   );
 }
 
-const VOICE_OPTIONS = [
-  "alloy",
-  "ash", 
-  "ballad",
-  "coral",
-  "echo",
-  "sage",
-  "shimmer",
-  "verse"
-];
 
 export default function ToolPanel({
   isSessionActive,
   sendClientEvent,
   events,
   selectedVoice,
-  setSelectedVoice,
 }) {
   const [functionAdded, setFunctionAdded] = useState(false);
   const [functionCallOutput, setFunctionCallOutput] = useState(null);
@@ -132,29 +121,6 @@ export default function ToolPanel({
 
   return (
     <section className="h-full w-full flex flex-col gap-4">
-      <div className="bg-gray-50 rounded-md p-4">
-        <h2 className="text-lg font-bold mb-4">Voice Settings</h2>
-        <div className="mb-4">
-          <label className="block text-sm font-medium mb-2">Select Voice</label>
-          <select
-            value={selectedVoice}
-            onChange={(e) => setSelectedVoice(e.target.value)}
-            disabled={isSessionActive}
-            className="w-full p-2 border border-gray-300 rounded-md text-sm disabled:bg-gray-100 disabled:cursor-not-allowed"
-          >
-            {VOICE_OPTIONS.map((voice) => (
-              <option key={voice} value={voice}>
-                {voice}
-              </option>
-            ))}
-          </select>
-          {isSessionActive && (
-            <p className="text-xs text-gray-500 mt-1">
-              Voice cannot be changed during an active session
-            </p>
-          )}
-        </div>
-      </div>
       <div className="flex-1 bg-gray-50 rounded-md p-4">
         <h2 className="text-lg font-bold">Color Palette Tool</h2>
         {isSessionActive ? (


### PR DESCRIPTION
Add Voice Options and Instructions configuration to the main page before session starts, and remove log streams as requested in issue #16.

## Changes
- Remove EventLog component and log stream functionality
- Add Voice Options configuration UI to main page before session starts
- Add Instructions textarea for system instructions
- Move voice settings from ToolPanel to main settings page
- Send system instructions when session opens
- Show session active status during conversation

Closes #16

Generated with [Claude Code](https://claude.ai/code)