### PR TITLE
feat: AIペルソナ設定機能とシーン設定機能を追加

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -18,6 +18,24 @@ export default function App() {
   const [selectedVoice, setSelectedVoice] = useState("alloy");
   const [instructions, setInstructions] = useState("");
   const [activeTab, setActiveTab] = useState("setup");
+  
+  // Persona settings
+  const [personaSettings, setPersonaSettings] = useState({
+    age: "",
+    gender: "",
+    occupation: "",
+    personality: "",
+    additionalInfo: ""
+  });
+  
+  // Scene settings
+  const [sceneSettings, setSceneSettings] = useState({
+    appointmentBackground: "",
+    relationship: "",
+    timeOfDay: "",
+    location: "",
+    additionalInfo: ""
+  });
   const [isListening, setIsListening] = useState(false);
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [audioLevel, setAudioLevel] = useState(0);
@@ -146,6 +164,42 @@ export default function App() {
     sendClientEvent({ type: "response.create" });
   }
 
+  // Build combined instructions from persona and scene settings
+  function buildCombinedInstructions() {
+    let combined = [];
+
+    // Add custom instructions if provided
+    if (instructions.trim()) {
+      combined.push(instructions.trim());
+    }
+
+    // Add persona settings
+    const personaInstructions = [];
+    if (personaSettings.age) personaInstructions.push(`年齢: ${personaSettings.age}`);
+    if (personaSettings.gender) personaInstructions.push(`性別: ${personaSettings.gender}`);
+    if (personaSettings.occupation) personaInstructions.push(`職業: ${personaSettings.occupation}`);
+    if (personaSettings.personality) personaInstructions.push(`パーソナリティ: ${personaSettings.personality}`);
+    if (personaSettings.additionalInfo) personaInstructions.push(`追加情報: ${personaSettings.additionalInfo}`);
+
+    if (personaInstructions.length > 0) {
+      combined.push(`あなたのペルソナ設定:\n${personaInstructions.join('\n')}`);
+    }
+
+    // Add scene settings
+    const sceneInstructions = [];
+    if (sceneSettings.appointmentBackground) sceneInstructions.push(`アポイントメントの背景: ${sceneSettings.appointmentBackground}`);
+    if (sceneSettings.relationship) sceneInstructions.push(`相手との関係性: ${sceneSettings.relationship}`);
+    if (sceneSettings.timeOfDay) sceneInstructions.push(`時間帯: ${sceneSettings.timeOfDay}`);
+    if (sceneSettings.location) sceneInstructions.push(`場所: ${sceneSettings.location}`);
+    if (sceneSettings.additionalInfo) sceneInstructions.push(`追加情報: ${sceneSettings.additionalInfo}`);
+
+    if (sceneInstructions.length > 0) {
+      combined.push(`シーン設定:\n${sceneInstructions.join('\n')}`);
+    }
+
+    return combined.join('\n\n');
+  }
+
   // Attach event listeners to the data channel when a new one is created
   useEffect(() => {
     if (dataChannel) {
@@ -180,7 +234,8 @@ export default function App() {
         setActiveTab("chat"); // Switch to chat tab when session starts
         
         // Send initial instructions if provided
-        if (instructions.trim()) {
+        const combinedInstructions = buildCombinedInstructions();
+        if (combinedInstructions.trim()) {
           setTimeout(() => {
             sendClientEvent({
               type: "conversation.item.create",
@@ -189,7 +244,7 @@ export default function App() {
                 role: "system",
                 content: [{
                   type: "input_text",
-                  text: instructions
+                  text: combinedInstructions
                 }]
               }
             });
@@ -197,7 +252,7 @@ export default function App() {
         }
       });
     }
-  }, [dataChannel, instructions]);
+  }, [dataChannel, instructions, personaSettings, sceneSettings]);
 
   // Handle tab switching with swipe gestures
   const handleSwipeLeft = () => {
@@ -247,6 +302,10 @@ export default function App() {
             setSelectedVoice={setSelectedVoice}
             instructions={instructions}
             setInstructions={setInstructions}
+            personaSettings={personaSettings}
+            setPersonaSettings={setPersonaSettings}
+            sceneSettings={sceneSettings}
+            setSceneSettings={setSceneSettings}
             startSession={startSession}
             VOICE_OPTIONS={VOICE_OPTIONS}
           />

--- a/client/components/SetupScreen.jsx
+++ b/client/components/SetupScreen.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronDown, ChevronUp, Play, Settings } from "react-feather";
+import { ChevronDown, ChevronUp, Play, Settings, User, MapPin } from "react-feather";
 import Button from "./Button";
 
 function ExpandableSection({ title, children, defaultExpanded = false, icon: Icon }) {
@@ -36,6 +36,10 @@ export default function SetupScreen({
   setSelectedVoice, 
   instructions, 
   setInstructions,
+  personaSettings,
+  setPersonaSettings,
+  sceneSettings,
+  setSceneSettings,
   startSession,
   VOICE_OPTIONS 
 }) {
@@ -92,6 +96,169 @@ export default function SetupScreen({
             <p className="text-xs text-gray-500 mt-2">
               選択済み: <span className="font-medium">{selectedVoice}</span>
             </p>
+          </div>
+        </ExpandableSection>
+
+        {/* Persona Settings */}
+        <ExpandableSection 
+          title="AIペルソナ設定" 
+          defaultExpanded={false}
+          icon={User}
+        >
+          <div className="pt-3 space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                年齢
+              </label>
+              <input
+                type="text"
+                value={personaSettings.age}
+                onChange={(e) => setPersonaSettings({...personaSettings, age: e.target.value})}
+                placeholder="例: 25歳"
+                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                性別
+              </label>
+              <select
+                value={personaSettings.gender}
+                onChange={(e) => setPersonaSettings({...personaSettings, gender: e.target.value})}
+                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                <option value="">選択してください</option>
+                <option value="男性">男性</option>
+                <option value="女性">女性</option>
+                <option value="その他">その他</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                職業
+              </label>
+              <input
+                type="text"
+                value={personaSettings.occupation}
+                onChange={(e) => setPersonaSettings({...personaSettings, occupation: e.target.value})}
+                placeholder="例: エンジニア、医師、教師など"
+                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                パーソナリティ
+              </label>
+              <textarea
+                value={personaSettings.personality}
+                onChange={(e) => setPersonaSettings({...personaSettings, personality: e.target.value})}
+                placeholder="例: 明るく親しみやすい、論理的で分析的、優しく思いやりがあるなど"
+                className="w-full p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                rows={3}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                追加情報
+              </label>
+              <textarea
+                value={personaSettings.additionalInfo}
+                onChange={(e) => setPersonaSettings({...personaSettings, additionalInfo: e.target.value})}
+                placeholder="その他の特徴や詳細情報があれば入力してください"
+                className="w-full p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                rows={2}
+              />
+            </div>
+          </div>
+        </ExpandableSection>
+
+        {/* Scene Settings */}
+        <ExpandableSection 
+          title="シーン設定" 
+          defaultExpanded={false}
+          icon={MapPin}
+        >
+          <div className="pt-3 space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                アポイントメントの背景
+              </label>
+              <textarea
+                value={sceneSettings.appointmentBackground}
+                onChange={(e) => setSceneSettings({...sceneSettings, appointmentBackground: e.target.value})}
+                placeholder="例: 新商品の打ち合わせ、健康診断、面接など"
+                className="w-full p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                rows={2}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                相手との関係性
+              </label>
+              <input
+                type="text"
+                value={sceneSettings.relationship}
+                onChange={(e) => setSceneSettings({...sceneSettings, relationship: e.target.value})}
+                placeholder="例: 同僚、友人、初対面、上司など"
+                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                時間帯
+              </label>
+              <select
+                value={sceneSettings.timeOfDay}
+                onChange={(e) => setSceneSettings({...sceneSettings, timeOfDay: e.target.value})}
+                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                <option value="">選択してください</option>
+                <option value="朝">朝</option>
+                <option value="午前">午前</option>
+                <option value="昼">昼</option>
+                <option value="午後">午後</option>
+                <option value="夕方">夕方</option>
+                <option value="夜">夜</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                場所
+              </label>
+              <input
+                type="text"
+                value={sceneSettings.location}
+                onChange={(e) => setSceneSettings({...sceneSettings, location: e.target.value})}
+                placeholder="例: オフィス、カフェ、病院、自宅など"
+                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                追加情報
+              </label>
+              <textarea
+                value={sceneSettings.additionalInfo}
+                onChange={(e) => setSceneSettings({...sceneSettings, additionalInfo: e.target.value})}
+                placeholder="シーンに関する追加情報があれば入力してください"
+                className="w-full p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                rows={2}
+              />
+            </div>
+
+            <div className="bg-blue-50 rounded-lg p-3">
+              <p className="text-sm text-blue-700">
+                これらの設定は会話の文脈を作り出し、より自然な対話を可能にします。
+              </p>
+            </div>
           </div>
         </ExpandableSection>
 


### PR DESCRIPTION
Issue #21で要求されたペルソナ設定機能を実装しました。

## 変更内容

**✅ AIペルソナ設定**
- 年齢入力フィールド
- 性別選択、職業入力
- パーソナリティ、追加情報

**✅ シーン設定**
- アポイントメント背景、関係性
- 時間帯選択、場所設定
- 追加情報フィールド

**✅ 統合機能**
- 設定をシステム指示に自動統合
- セッション開始時に設定が自動適用

Closes #21

Generated with [Claude Code](https://claude.ai/code)