### PR TITLE
feat: システム指示のデフォルト値を日本語に設定

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -16,7 +16,7 @@ export default function App() {
   const [events, setEvents] = useState([]);
   const [dataChannel, setDataChannel] = useState(null);
   const [selectedVoice, setSelectedVoice] = useState("alloy");
-  const [instructions, setInstructions] = useState("");
+  const [instructions, setInstructions] = useState("自然な日本語で応対します。");
   const [activeTab, setActiveTab] = useState("setup");
   
   // Persona settings


### PR DESCRIPTION
Fixes #23

システム指示のデフォルト値を「自然な日本語で応対します。」に変更しました。

✅ 変更内容
- `client/components/App.jsx` でシステム指示の初期値を設定
- 新しいセッションでデフォルトで日本語対応が有効に

Generated with [Claude Code](https://claude.ai/code)