### PR TITLE
Move GROQ_API_KEY to backend for security

### DIFF
--- a/VERCEL_ENV_SETUP.md
+++ b/VERCEL_ENV_SETUP.md
@@ -1,0 +1,82 @@
+# Vercel Environment Variables Setup
+
+This document explains how to properly configure environment variables for the OpenAI Realtime Console application when deployed on Vercel.
+
+## Required Environment Variables
+
+### Backend API Keys (Server-side only)
+These variables are kept secure on the server and never exposed to clients:
+
+- **`OPENAI_API_KEY`**: Your OpenAI API key for Realtime API access
+- **`GROQ_API_KEY`**: Your GROQ API key for AI instruction generation
+
+### Optional Environment Variables
+- **`VERCEL_ENV`**: Automatically set by Vercel (production, preview, development)
+
+## Setup Instructions
+
+### 1. Via Vercel Dashboard
+1. Go to your project's Vercel dashboard
+2. Navigate to Settings → Environment Variables
+3. Add the following variables:
+   - Name: `OPENAI_API_KEY`, Value: `your-openai-api-key`
+   - Name: `GROQ_API_KEY`, Value: `your-groq-api-key`
+4. Make sure to set them for all environments (Production, Preview, Development)
+
+### 2. Via Vercel CLI
+```bash
+vercel env add OPENAI_API_KEY
+vercel env add GROQ_API_KEY
+```
+
+## Security Model
+
+### ✅ Secure Backend Approach (Current)
+- API keys are stored as server-side environment variables
+- Client makes requests to `/api/token` and `/api/groq` endpoints
+- API keys never leave the server environment
+- CORS properly configured for client access
+
+### ❌ Previous Insecure Approach (Fixed)
+- ~~`VITE_GROQ_API_KEY` exposed API key to client-side~~
+- ~~Client-side direct API calls exposed sensitive credentials~~
+
+## Troubleshooting
+
+### API Key Not Found
+If you see "API_KEY: Missing" in logs:
+1. Verify the environment variable is set in Vercel dashboard
+2. Check the variable name matches exactly (case-sensitive)
+3. Redeploy after adding environment variables
+
+### GROQ API Issues
+- The application now uses secure backend endpoints for GROQ processing
+- Remove any `VITE_GROQ_API_KEY` variables as they're no longer needed
+- Set only `GROQ_API_KEY` as a server-side environment variable
+
+### Vercel Environment Detection
+- `VERCEL_ENV` is automatically set by Vercel
+- Possible values: `production`, `preview`, `development`
+- This helps with environment-specific configurations
+
+## API Endpoints
+
+### `/api/token` (OpenAI Realtime)
+- Method: GET
+- Purpose: Generate OpenAI Realtime API session tokens
+- Authentication: Uses `OPENAI_API_KEY` server-side
+
+### `/api/groq` (GROQ Processing)
+- Method: POST
+- Purpose: Generate AI conversation instructions
+- Authentication: Uses `GROQ_API_KEY` server-side
+- Body: `{ "context": "conversation context" }` or `{ "prompt": "custom prompt" }`
+
+## Testing Environment Variables
+
+Both API endpoints will log the status of environment variables at startup:
+- `OPENAI_API_KEY: Set/Missing`
+- `GROQ_API_KEY: Set/Missing`
+- `VERCEL_ENV: production/preview/development`
+
+Check your Vercel deployment logs to verify all required variables are properly configured.

--- a/api/groq.js
+++ b/api/groq.js
@@ -1,0 +1,84 @@
+import "dotenv/config";
+import Groq from 'groq-sdk';
+
+const groqApiKey = process.env.GROQ_API_KEY;
+
+// Log API key status at startup
+console.log('GROQ_API_KEY:', groqApiKey ? 'Set' : 'Missing');
+console.log('VERCEL_ENV:', process.env.VERCEL_ENV);
+
+export default async function handler(req, res) {
+  // Handle CORS
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  
+  if (req.method === 'OPTIONS') {
+    res.status(200).end();
+    return;
+  }
+
+  // Check if GROQ API key is configured
+  if (!groqApiKey) {
+    console.error('GROQ_API_KEYが設定されていません');
+    res.status(500).json({ 
+      error: 'GROQ_API_KEYが設定されていません。環境変数を確認してください。' 
+    });
+    return;
+  }
+
+  // Only handle POST requests
+  if (req.method === 'POST') {
+    try {
+      const { prompt, context } = req.body;
+
+      if (!prompt && !context) {
+        res.status(400).json({ error: 'promptまたはcontextが必要です' });
+        return;
+      }
+
+      const groq = new Groq({ apiKey: groqApiKey });
+
+      let finalPrompt = prompt;
+
+      // If context is provided, generate detailed instructions
+      if (context && !prompt) {
+        finalPrompt = `以下の文脈に基づいて、音声会話AI用の詳細な指示文を日本語で作成してください。指示文は自然で包括的で、AIが適切に対応できるように具体的である必要があります。
+
+文脈: ${context || '一般的な音声会話'}
+
+以下の要素を含む詳細な指示文を作成してください：
+1. 基本的な対応スタイル
+2. 言語使用のガイドライン
+3. 会話の流れの管理
+4. 適切な応答の例
+
+指示文:`;
+      }
+
+      const completion = await groq.chat.completions.create({
+        model: 'moonshotai/kimi-k2-instruct',
+        messages: [
+          {
+            role: 'user',
+            content: finalPrompt
+          }
+        ],
+        temperature: 0.7,
+        max_tokens: 1000
+      });
+
+      const content = completion.choices[0]?.message?.content || '';
+      
+      res.status(200).json({ content });
+    } catch (error) {
+      console.error('Groq API request failed:', error);
+      res.status(500).json({ 
+        error: 'Groq APIリクエストが失敗しました',
+        message: error.message 
+      });
+    }
+  } else {
+    res.status(405).json({ error: 'Method not allowed' });
+  }
+}

--- a/api/token.js
+++ b/api/token.js
@@ -2,6 +2,11 @@ import "dotenv/config";
 
 const apiKey = process.env.OPENAI_API_KEY;
 
+// Log API key status at startup
+console.log('OPENAI_API_KEY:', apiKey ? 'Set' : 'Missing');
+console.log('GROQ_API_KEY:', process.env.GROQ_API_KEY ? 'Set' : 'Missing');
+console.log('VERCEL_ENV:', process.env.VERCEL_ENV);
+
 export default async function handler(req, res) {
   // Handle CORS
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -10,6 +15,15 @@ export default async function handler(req, res) {
   
   if (req.method === 'OPTIONS') {
     res.status(200).end();
+    return;
+  }
+
+  // Check if OPENAI API key is configured
+  if (!apiKey) {
+    console.error('OPENAI_API_KEYが設定されていません');
+    res.status(500).json({ 
+      error: 'OPENAI_API_KEYが設定されていません。環境変数を確認してください。' 
+    });
     return;
   }
 

--- a/client/services/groq.js
+++ b/client/services/groq.js
@@ -1,50 +1,31 @@
 /**
  * Groq API integration for Kimi K2 instruction generation
+ * Now uses secure backend API endpoint instead of client-side API calls
  */
-import Groq from 'groq-sdk';
 
 class GroqService {
   constructor() {
-    // In a browser environment, we'll need to pass the API key from the environment
-    // Since this is a client-side application, we should handle the API key securely
-    this.groq = null;
-    this.model = 'moonshotai/kimi-k2-instruct';
-  }
-
-  initializeGroq(apiKey) {
-    if (!apiKey) {
-      throw new Error('GROQ_API_KEY環境変数が設定されていません');
-    }
-    this.groq = new Groq({ apiKey });
+    // Backend API endpoint for secure GROQ processing
+    this.apiEndpoint = '/api/groq';
   }
 
   async generateInstructions(prompt) {
-    // For client-side usage, we'll need to get the API key from somewhere
-    // For now, let's use import.meta.env for Vite
-    const apiKey = import.meta.env.VITE_GROQ_API_KEY || process.env.GROQ_API_KEY;
-    
-    if (!apiKey) {
-      throw new Error('GROQ_API_KEY環境変数が設定されていません。VITE_GROQ_API_KEYまたはGROQ_API_KEYを設定してください。');
-    }
-
-    if (!this.groq) {
-      this.initializeGroq(apiKey);
-    }
-
     try {
-      const completion = await this.groq.chat.completions.create({
-        model: this.model,
-        messages: [
-          {
-            role: 'user',
-            content: prompt
-          }
-        ],
-        temperature: 0.7,
-        max_tokens: 1000
+      const response = await fetch(this.apiEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ prompt })
       });
 
-      return completion.choices[0]?.message?.content || '';
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data.content || '';
     } catch (error) {
       console.error('Groq API request failed:', error);
       throw error;
@@ -52,19 +33,26 @@ class GroqService {
   }
 
   async generateDetailedInstructions(context = '') {
-    const prompt = `以下の文脈に基づいて、音声会話AI用の詳細な指示文を日本語で作成してください。指示文は自然で包括的で、AIが適切に対応できるように具体的である必要があります。
+    try {
+      const response = await fetch(this.apiEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ context })
+      });
 
-文脈: ${context || '一般的な音声会話'}
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
+      }
 
-以下の要素を含む詳細な指示文を作成してください：
-1. 基本的な対応スタイル
-2. 言語使用のガイドライン
-3. 会話の流れの管理
-4. 適切な応答の例
-
-指示文:`;
-
-    return await this.generateInstructions(prompt);
+      const data = await response.json();
+      return data.content || '';
+    } catch (error) {
+      console.error('Groq API request failed:', error);
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
Move GROQ API processing to secure backend endpoints to protect sensitive API keys from client-side exposure.

## Changes
- Create secure `/api/groq` endpoint for GROQ processing
- Refactor client-side groq service to use backend API
- Remove client-side API key exposure (VITE_GROQ_API_KEY)
- Add proper API key validation and startup logging
- Update environment variable documentation with security model

## Security Improvements
- ✅ API keys now properly secured server-side
- ✅ No sensitive credentials exposed to browser
- ✅ Secure backend API endpoints with proper CORS

Fixes #32

Generated with [Claude Code](https://claude.ai/code)