### PR TITLE
プロンプト生成機能を実装

### DIFF
--- a/client/components/PromptModal.jsx
+++ b/client/components/PromptModal.jsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { X, Play } from "react-feather";
 import Button from "./Button";
 
@@ -7,6 +8,13 @@ export default function PromptModal({
   promptText, 
   onStartSession 
 }) {
+  const [editedPrompt, setEditedPrompt] = useState("");
+
+  // Update edited prompt when promptText changes
+  useEffect(() => {
+    setEditedPrompt(promptText);
+  }, [promptText]);
+
   if (!isOpen) return null;
 
   return (
@@ -28,13 +36,16 @@ export default function PromptModal({
         {/* Content */}
         <div className="p-4">
           <p className="text-sm text-gray-600 mb-4">
-            このプロンプトで会話を始めます
+            プロンプトを確認・編集して会話を始めます
           </p>
           
-          <div className="bg-gray-50 rounded-lg p-4 mb-6 max-h-60 overflow-y-auto">
-            <pre className="text-sm text-gray-800 whitespace-pre-wrap font-mono">
-              {promptText}
-            </pre>
+          <div className="mb-6">
+            <textarea
+              value={editedPrompt}
+              onChange={(e) => setEditedPrompt(e.target.value)}
+              className="w-full h-60 p-4 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono"
+              placeholder="プロンプトを入力してください..."
+            />
           </div>
 
           {/* Action Buttons */}
@@ -46,7 +57,7 @@ export default function PromptModal({
               キャンセル
             </button>
             <Button
-              onClick={onStartSession}
+              onClick={() => onStartSession(editedPrompt)}
               className="flex-1 bg-green-600 hover:bg-green-700"
               icon={<Play size={16} />}
             >

--- a/client/components/PromptModal.jsx
+++ b/client/components/PromptModal.jsx
@@ -6,7 +6,8 @@ export default function PromptModal({
   isOpen, 
   onClose, 
   promptText, 
-  onStartSession 
+  onStartSession,
+  hasSettingsChanges = true
 }) {
   const [editedPrompt, setEditedPrompt] = useState("");
 
@@ -23,7 +24,7 @@ export default function PromptModal({
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-200">
           <h2 className="text-lg font-semibold text-gray-800">
-            生成されたプロンプト
+            {hasSettingsChanges ? '生成されたプロンプト' : 'カスタム指示入力'}
           </h2>
           <button
             onClick={onClose}
@@ -36,7 +37,10 @@ export default function PromptModal({
         {/* Content */}
         <div className="p-4">
           <p className="text-sm text-gray-600 mb-4">
-            プロンプトを確認・編集して会話を始めます
+            {hasSettingsChanges 
+              ? 'プロンプトを確認・編集して会話を始めます' 
+              : 'カスタム指示を入力して会話を始めます'
+            }
           </p>
           
           <div className="mb-6">
@@ -44,7 +48,10 @@ export default function PromptModal({
               value={editedPrompt}
               onChange={(e) => setEditedPrompt(e.target.value)}
               className="w-full h-60 p-4 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono"
-              placeholder="プロンプトを入力してください..."
+              placeholder={hasSettingsChanges 
+                ? 'プロンプトを入力してください...' 
+                : 'AIアシスタントへのカスタム指示を入力してください...'
+              }
             />
           </div>
 

--- a/client/components/PromptModal.jsx
+++ b/client/components/PromptModal.jsx
@@ -1,0 +1,60 @@
+import { X, Play } from "react-feather";
+import Button from "./Button";
+
+export default function PromptModal({ 
+  isOpen, 
+  onClose, 
+  promptText, 
+  onStartSession 
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full max-h-[80vh] overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-800">
+            生成されたプロンプト
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-4">
+          <p className="text-sm text-gray-600 mb-4">
+            このプロンプトで会話を始めます
+          </p>
+          
+          <div className="bg-gray-50 rounded-lg p-4 mb-6 max-h-60 overflow-y-auto">
+            <pre className="text-sm text-gray-800 whitespace-pre-wrap font-mono">
+              {promptText}
+            </pre>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="flex-1 px-4 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+            >
+              キャンセル
+            </button>
+            <Button
+              onClick={onStartSession}
+              className="flex-1 bg-green-600 hover:bg-green-700"
+              icon={<Play size={16} />}
+            >
+              会話を開始
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/components/SetupScreen.jsx
+++ b/client/components/SetupScreen.jsx
@@ -93,7 +93,7 @@ export default function SetupScreen({
           // Generate prompt using Groq service
           promptToUse = await groqService.generateDetailedInstructions(context);
         } else {
-          promptToUse = "自然な日本語で応対します。";
+          promptToUse = "";
         }
       }
       

--- a/client/components/SetupScreen.jsx
+++ b/client/components/SetupScreen.jsx
@@ -107,8 +107,12 @@ export default function SetupScreen({
     }
   };
 
-  const handleStartSession = async () => {
+  const handleStartSession = async (editedPrompt) => {
     try {
+      // Update instructions with the edited prompt before starting session
+      if (editedPrompt !== undefined) {
+        setInstructions(editedPrompt);
+      }
       await startSession();
       setShowPromptModal(false);
     } catch (error) {


### PR DESCRIPTION
プロンプト生成機能を要件通りに実装しました。

## 変更内容

- 「音声セッション開始」ボタンを「プロンプト生成」に変更
- システム指示が入力されている場合、AIペルソナ設定とシーン設定を無視してシステム指示をロールプレイAIのプロンプトに昇格
- AIペルソナ設定とシーン設定からKimi K2がロールプレイAI向けのプロンプトを生成
- 「このプロンプトで会話を始めます」メッセージと共にプロンプトを表示するポップアップ機能
- 「会話を開始」タップで会話セッションをスタート

Closes #34

Generated with [Claude Code](https://claude.ai/code)