### PR TITLE
fix: add missing openai dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "groq-sdk": "^0.7.0",
     "history": "^5.3.0",
     "minipass": "^7.0.4",
+    "openai": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-feather": "^2.0.10",


### PR DESCRIPTION
Fixes audio test error in popup by adding the openai package that was being imported in api/tts.js but not declared as a dependency.

Resolves #40

Generated with [Claude Code](https://claude.ai/code)