### PR TITLE
feat: update Voice Options to support only specified lowercase voices

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -44,18 +44,11 @@ export default function App() {
 
   const VOICE_OPTIONS = [
     "alloy",
-    "ash", 
-    "ballad",
-    "breeze",
-    "coral",
-    "echo",
-    "ember",
-    "fable",
-    "juniper",
     "nova",
-    "sage",
-    "shimmer",
-    "verse"
+    "echo",
+    "fable",
+    "onyx",
+    "shimmer"
   ];
 
   async function startSession() {


### PR DESCRIPTION
Updated VOICE_OPTIONS to include only the 6 requested lowercase voices: alloy, nova, echo, fable, onyx, shimmer.

Closes #42

🤖 Generated with [Claude Code](https://claude.ai/code)