### PR TITLE
UI adjustments: Change settings icon to person and increase purpose font size

### DIFF
--- a/client/components/SetupScreen.jsx
+++ b/client/components/SetupScreen.jsx
@@ -159,7 +159,7 @@ export default function SetupScreen({
         {/* Purpose Setting */}
         <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
           <div className="flex items-center gap-3 mb-3">
-            <h2 className="font-semibold text-gray-800">目的</h2>
+            <h2 className="text-lg font-semibold text-gray-800">目的</h2>
           </div>
           <textarea
             value={purpose}

--- a/client/components/TabNavigation.jsx
+++ b/client/components/TabNavigation.jsx
@@ -1,10 +1,10 @@
-import { Settings, MessageCircle, Clock, Sliders } from "react-feather";
+import { User, MessageCircle, Clock, Sliders } from "react-feather";
 
 const TABS = [
   { id: 'setup', label: 'セットアップ', icon: Sliders },
   { id: 'chat', label: 'チャット', icon: MessageCircle },
   { id: 'history', label: '履歴', icon: Clock },
-  { id: 'settings', label: '設定', icon: Settings }
+  { id: 'settings', label: '設定', icon: User }
 ];
 
 export default function TabNavigation({ activeTab, onTabChange, className = "" }) {


### PR DESCRIPTION
## Summary
- Replace Settings (gear) icon with User icon in TabNavigation for more human-centric design
- Increase "目的" (purpose) text size from font-semibold to text-lg font-semibold to match hierarchy

## Test plan
- [ ] Verify settings tab now shows person icon instead of gear
- [ ] Confirm "目的" text appears slightly larger than persona/scene section titles
- [ ] Test overall UI still functions correctly

Fixes #50

🤖 Generated with [Claude Code](https://claude.ai/code)