### PR TITLE
feat: URLルーティング実装

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Routes, Route, Navigate, useNavigate, useLocation } from "react-router-dom";
 import logo from "../assets/openai-logomark.svg";
 import TabNavigation from "./TabNavigation";
 import SetupScreen from "./SetupScreen";
@@ -21,7 +22,9 @@ export default function App() {
   const [dataChannel, setDataChannel] = useState(null);
   const [selectedVoice, setSelectedVoice] = useState("alloy");
   const [instructions, setInstructions] = useState("自然な日本語で応対します。");
-  const [activeTab, setActiveTab] = useState("setup");
+  
+  const navigate = useNavigate();
+  const location = useLocation();
   
   // Purpose setting
   const [purpose, setPurpose] = useState("");
@@ -262,7 +265,7 @@ export default function App() {
       dataChannel.addEventListener("open", () => {
         setIsSessionActive(true);
         setEvents([]);
-        setActiveTab("chat"); // Switch to chat tab when session starts
+        navigate("/roleplay"); // Switch to roleplay route when session starts
         
         // Send initial instructions if provided
         const combinedInstructions = buildCombinedInstructions();
@@ -283,7 +286,7 @@ export default function App() {
         }
       });
     }
-  }, [dataChannel, instructions, personaSettings, sceneSettings, purpose]);
+  }, [dataChannel, instructions, personaSettings, sceneSettings, purpose, navigate]);
 
 
   // Clear history function
@@ -291,66 +294,12 @@ export default function App() {
     setEvents([]);
   };
 
-  // Stop session and switch to setup tab
+  // Stop session and switch to setup route
   const handleStopSession = () => {
     stopSession();
-    setActiveTab("setup");
+    navigate("/setup");
   };
 
-  // Render current tab content
-  const renderTabContent = () => {
-    switch (activeTab) {
-      case 'setup':
-        return (
-          <SetupScreen
-            selectedVoice={selectedVoice}
-            setSelectedVoice={setSelectedVoice}
-            instructions={instructions}
-            setInstructions={setInstructions}
-            purpose={purpose}
-            setPurpose={setPurpose}
-            personaSettings={personaSettings}
-            setPersonaSettings={setPersonaSettings}
-            sceneSettings={sceneSettings}
-            setSceneSettings={setSceneSettings}
-            startSession={startSession}
-            VOICE_OPTIONS={VOICE_OPTIONS}
-          />
-        );
-      
-      case 'chat':
-        return (
-          <ChatInterface
-            events={events}
-            sendTextMessage={sendTextMessage}
-            isSessionActive={isSessionActive}
-            isTyping={isSpeaking}
-          />
-        );
-      
-      case 'history':
-        return (
-          <HistoryScreen
-            events={events}
-            onClearHistory={handleClearHistory}
-          />
-        );
-      
-      case 'settings':
-        return (
-          <SettingsScreen
-            selectedVoice={selectedVoice}
-            setSelectedVoice={setSelectedVoice}
-            VOICE_OPTIONS={VOICE_OPTIONS}
-            instructions={instructions}
-            setInstructions={setInstructions}
-          />
-        );
-      
-      default:
-        return null;
-    }
-  };
 
   // 認証されていない場合はログイン画面を表示
   if (!isAuthenticated) {
@@ -397,16 +346,65 @@ export default function App() {
       {/* Main content area */}
       <div className="flex-1 relative">
         <div className="h-full flex flex-col">
-          {renderTabContent()}
+          <Routes>
+            <Route path="/" element={<Navigate to="/setup" replace />} />
+            <Route 
+              path="/setup" 
+              element={
+                <SetupScreen
+                  selectedVoice={selectedVoice}
+                  setSelectedVoice={setSelectedVoice}
+                  instructions={instructions}
+                  setInstructions={setInstructions}
+                  purpose={purpose}
+                  setPurpose={setPurpose}
+                  personaSettings={personaSettings}
+                  setPersonaSettings={setPersonaSettings}
+                  sceneSettings={sceneSettings}
+                  setSceneSettings={setSceneSettings}
+                  startSession={startSession}
+                  VOICE_OPTIONS={VOICE_OPTIONS}
+                />
+              } 
+            />
+            <Route 
+              path="/roleplay" 
+              element={
+                <ChatInterface
+                  events={events}
+                  sendTextMessage={sendTextMessage}
+                  isSessionActive={isSessionActive}
+                  isTyping={isSpeaking}
+                />
+              } 
+            />
+            <Route 
+              path="/history" 
+              element={
+                <HistoryScreen
+                  events={events}
+                  onClearHistory={handleClearHistory}
+                />
+              } 
+            />
+            <Route 
+              path="/settings" 
+              element={
+                <SettingsScreen
+                  selectedVoice={selectedVoice}
+                  setSelectedVoice={setSelectedVoice}
+                  VOICE_OPTIONS={VOICE_OPTIONS}
+                  instructions={instructions}
+                  setInstructions={setInstructions}
+                />
+              } 
+            />
+          </Routes>
         </div>
       </div>
 
       {/* Tab Navigation */}
-      <TabNavigation
-        activeTab={activeTab}
-        onTabChange={setActiveTab}
-        className="flex-shrink-0"
-      />
+      <TabNavigation className="flex-shrink-0" />
       
       {/* Desktop tool panel (hidden on mobile) */}
       <div className="hidden lg:block fixed top-16 right-4 bottom-16 w-80 bg-white rounded-lg shadow-lg border border-gray-200 overflow-hidden">

--- a/client/components/TabNavigation.jsx
+++ b/client/components/TabNavigation.jsx
@@ -1,29 +1,37 @@
 import { User, MessageCircle, Clock, Sliders } from "react-feather";
+import { Link, useLocation } from "react-router-dom";
 
 const TABS = [
-  { id: 'setup', label: 'セットアップ', icon: Sliders },
-  { id: 'chat', label: 'チャット', icon: MessageCircle },
-  { id: 'history', label: '履歴', icon: Clock },
-  { id: 'settings', label: '設定', icon: User }
+  { id: 'setup', label: 'セットアップ', icon: Sliders, path: '/setup' },
+  { id: 'chat', label: 'チャット', icon: MessageCircle, path: '/roleplay' },
+  { id: 'history', label: '履歴', icon: Clock, path: '/history' },
+  { id: 'settings', label: '設定', icon: User, path: '/settings' }
 ];
 
-export default function TabNavigation({ activeTab, onTabChange, className = "" }) {
+export default function TabNavigation({ className = "" }) {
+  const location = useLocation();
+  
   return (
     <nav className={`flex bg-white border-t border-gray-200 shadow-lg ${className}`}>
-      {TABS.map(({ id, label, icon: Icon }) => (
-        <button
-          key={id}
-          onClick={() => onTabChange(id)}
-          className={`flex-1 flex flex-col items-center justify-center py-2 px-1 min-h-[60px] transition-colors ${
-            activeTab === id
-              ? 'text-blue-600 bg-blue-50 border-t-2 border-blue-600'
-              : 'text-gray-600 hover:text-gray-800 hover:bg-gray-50'
-          }`}
-        >
-          <Icon size={20} className="mb-1" />
-          <span className="text-xs font-medium">{label}</span>
-        </button>
-      ))}
+      {TABS.map(({ id, label, icon: Icon, path }) => {
+        const isActive = location.pathname === path || 
+          (path === '/setup' && location.pathname === '/');
+        
+        return (
+          <Link
+            key={id}
+            to={path}
+            className={`flex-1 flex flex-col items-center justify-center py-2 px-1 min-h-[60px] transition-colors ${
+              isActive
+                ? 'text-blue-600 bg-blue-50 border-t-2 border-blue-600'
+                : 'text-gray-600 hover:text-gray-800 hover:bg-gray-50'
+            }`}
+          >
+            <Icon size={20} className="mb-1" />
+            <span className="text-xs font-medium">{label}</span>
+          </Link>
+        );
+      })}
     </nav>
   );
 }

--- a/client/entry-client.jsx
+++ b/client/entry-client.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./components/App";
 import "./base.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 );


### PR DESCRIPTION
URLルーティングをReact Routerで実装しました。

## 主な変更点
- React Router DOMを使用したURL routing実装
- タブベースの状態管理をルーターに置き換え
- ブラウザの戻る/進むボタンが動作
- 直接URLアクセスが可能

## 新しいURL構造
- `/setup` - プリセット/微調整画面
- `/roleplay` - ロープレ中画面
- `/history` - 履歴画面
- `/settings` - 設定画面

Closes #71

🤖 Generated with [Claude Code](https://claude.ai/code)