### PR TITLE
Simplify app to 3 screens: login, roleplay setup, and active roleplay

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -5,8 +5,6 @@ import TabNavigation from "./TabNavigation";
 import SetupScreen from "./SetupScreen";
 import VoiceInterface from "./VoiceInterface";
 import ChatInterface from "./ChatInterface";
-import HistoryScreen from "./HistoryScreen";
-import SettingsScreen from "./SettingsScreen";
 import SessionControls from "./SessionControls";
 import ToolPanel from "./ToolPanel";
 import LoginScreen from "./LoginScreen";
@@ -289,10 +287,6 @@ export default function App() {
   }, [dataChannel, instructions, personaSettings, sceneSettings, purpose, navigate]);
 
 
-  // Clear history function
-  const handleClearHistory = () => {
-    setEvents([]);
-  };
 
   // Stop session and switch to setup route
   const handleStopSession = () => {
@@ -377,27 +371,6 @@ export default function App() {
                   sendTextMessage={sendTextMessage}
                   isSessionActive={isSessionActive}
                   isTyping={isSpeaking}
-                />
-              } 
-            />
-            <Route 
-              path="/history" 
-              element={
-                <HistoryScreen
-                  events={events}
-                  onClearHistory={handleClearHistory}
-                />
-              } 
-            />
-            <Route 
-              path="/settings" 
-              element={
-                <SettingsScreen
-                  selectedVoice={selectedVoice}
-                  setSelectedVoice={setSelectedVoice}
-                  VOICE_OPTIONS={VOICE_OPTIONS}
-                  instructions={instructions}
-                  setInstructions={setInstructions}
                 />
               } 
             />

--- a/client/components/TabNavigation.jsx
+++ b/client/components/TabNavigation.jsx
@@ -1,11 +1,9 @@
-import { User, MessageCircle, Clock, Sliders } from "react-feather";
+import { MessageCircle, Sliders } from "react-feather";
 import { Link, useLocation } from "react-router-dom";
 
 const TABS = [
   { id: 'setup', label: 'セットアップ', icon: Sliders, path: '/setup' },
-  { id: 'chat', label: 'チャット', icon: MessageCircle, path: '/roleplay' },
-  { id: 'history', label: '履歴', icon: Clock, path: '/history' },
-  { id: 'settings', label: '設定', icon: User, path: '/settings' }
+  { id: 'chat', label: 'チャット', icon: MessageCircle, path: '/roleplay' }
 ];
 
 export default function TabNavigation({ className = "" }) {


### PR DESCRIPTION
Simplify the application structure to only include the 3 essential screens as requested:

- ログイン画面 (Login Screen)
- ロープレ設定画面 (Roleplay Settings)
- ロープレ中画面 (During Roleplay)

## Changes:
- Removed HistoryScreen and SettingsScreen components
- Updated navigation to show only 2 tabs (setup & chat)
- Cleaned up unused imports and functions
- Maintained all core functionality for roleplay features

Fixes #80

Generated with [Claude Code](https://claude.ai/code)