### PR TITLE
fix: improve responsive design and mobile scrolling

### DIFF
--- a/client/base.css
+++ b/client/base.css
@@ -17,12 +17,14 @@ body {
   width: 100%;
   margin: 0;
   padding: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   font-family: "Consolas", "Andale Mono", monospace;
   font-size: 0.9rem;
   background-color: var(--color-base);
   -webkit-text-size-adjust: 100%;
   touch-action: manipulation;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* Improve mobile touch targets and scrolling */
@@ -31,7 +33,22 @@ body {
     font-size: 0.85rem;
   }
   
-  input, button {
+  input, button, textarea {
     font-size: 16px; /* Prevent zoom on iOS */
+  }
+}
+
+/* Ensure proper scrolling on mobile */
+#root {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Fix mobile viewport height issues */
+@supports (-webkit-touch-callout: none) {
+  #root {
+    height: -webkit-fill-available;
   }
 }

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -405,7 +405,7 @@ export default function App() {
         <div className="p-4 border-b border-gray-200">
           <h3 className="font-semibold text-gray-800">Tools & Events</h3>
         </div>
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto p-4">
           <ToolPanel
             sendClientEvent={sendClientEvent}
             sendTextMessage={sendTextMessage}

--- a/client/components/ChatInterface.jsx
+++ b/client/components/ChatInterface.jsx
@@ -180,7 +180,7 @@ export default function ChatInterface({
       </div>
 
       {/* Messages area - with responsive padding for desktop tool panel */}
-      <div className="flex-1 overflow-y-auto p-3 sm:p-4 xl:pr-[340px] space-y-2 pb-20 relative">
+      <div className="flex-1 overflow-y-auto p-3 sm:p-4 xl:pr-[340px] space-y-2 pb-32 sm:pb-28 relative">
         {/* Mute status overlay */}
         {isMuted && (
           <div className="fixed top-20 left-1/2 transform -translate-x-1/2 bg-red-500 text-white px-4 py-2 rounded-full shadow-lg z-20 flex items-center gap-2">
@@ -210,7 +210,7 @@ export default function ChatInterface({
       </div>
 
       {/* Input area - Fixed at bottom with responsive padding */}
-      <div className="fixed bottom-16 left-0 right-0 xl:right-[320px] border-t border-gray-200 p-3 sm:p-4 bg-white z-10">
+      <div className="fixed bottom-14 sm:bottom-16 left-0 right-0 xl:right-[320px] border-t border-gray-200 p-3 sm:p-4 bg-white z-10 safe-area-inset-bottom">
         <div className="flex gap-2 items-end max-w-4xl mx-auto">
           <div className="flex-1 min-w-0">
             <textarea

--- a/client/components/SetupScreen.jsx
+++ b/client/components/SetupScreen.jsx
@@ -192,7 +192,7 @@ export default function SetupScreen({
 
   return (
     <div className="flex-1 overflow-y-auto p-3 sm:p-4 xl:pr-[340px] bg-gray-50">
-      <div className="max-w-md mx-auto space-y-3 sm:space-y-4 pb-4">
+      <div className="max-w-md mx-auto space-y-3 sm:space-y-4 pb-20 safe-area-inset-bottom">
         {/* Header */}
         <div className="text-center py-6">
           <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">

--- a/client/components/ToolPanel.jsx
+++ b/client/components/ToolPanel.jsx
@@ -121,8 +121,8 @@ export default function ToolPanel({
 
   return (
     <section className="h-full w-full flex flex-col gap-4">
-      <div className="flex-1 bg-gray-50 rounded-md p-4">
-        <h2 className="text-lg font-bold">Color Palette Tool</h2>
+      <div className="flex-1 bg-gray-50 rounded-md p-3">
+        <h2 className="text-base font-bold mb-3">Color Palette Tool</h2>
         {isSessionActive ? (
           functionCallOutput ? (
             <FunctionCallOutput functionCallOutput={functionCallOutput} />


### PR DESCRIPTION
Fixes responsive design issues and mobile scrolling problems reported in #84.

## Changes:
- Fix body overflow to allow proper scrolling
- Add mobile viewport height fixes with -webkit-fill-available
- Improve chat interface spacing with proper bottom padding
- Adjust input positioning for better mobile layout
- Add safe area support for modern mobile devices
- Fix tool panel layout and spacing
- Prevent iOS zoom by setting font-size on form elements

Closes #84

Generated with [Claude Code](https://claude.ai/code)