### PR TITLE
Simplify roleplay screen to show only essential elements

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -390,6 +390,10 @@ export default function App() {
                   isListening={isListening}
                   isSpeaking={isSpeaking}
                   audioLevel={audioLevel}
+                  personaSettings={personaSettings}
+                  sceneSettings={sceneSettings}
+                  purpose={purpose}
+                  onStopSession={handleStopSession}
                 />
               } 
             />

--- a/client/components/ChatInterface.jsx
+++ b/client/components/ChatInterface.jsx
@@ -1,186 +1,112 @@
-import { useState, useRef, useEffect } from "react";
-import { Send, User, MessageCircle, Mic, MicOff } from "react-feather";
-import VoiceInterface from "./VoiceInterface";
-
-function MessageBubble({ message, isUser, timestamp }) {
-  return (
-    <div className={`flex gap-3 mb-4 ${isUser ? 'flex-row-reverse' : 'flex-row'}`}>
-      {/* Avatar */}
-      <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
-        isUser ? 'bg-blue-500' : 'bg-gray-500'
-      }`}>
-        {isUser ? <User size={16} className="text-white" /> : <MessageCircle size={16} className="text-white" />}
-      </div>
-      
-      {/* Message bubble */}
-      <div className={`max-w-[70%] min-w-0 ${isUser ? 'items-end' : 'items-start'} flex flex-col`}>
-        <div className={`rounded-2xl px-4 py-2 break-words word-wrap overflow-wrap-anywhere ${
-          isUser 
-            ? 'bg-blue-500 text-white rounded-br-md' 
-            : 'bg-gray-200 text-gray-800 rounded-bl-md'
-        }`}>
-          <p className="text-sm leading-relaxed break-words">{message}</p>
-        </div>
-        
-        {/* Timestamp */}
-        {timestamp && (
-          <span className="text-xs text-gray-500 mt-1 px-1">
-            {timestamp}
-          </span>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function TypingIndicator() {
-  return (
-    <div className="flex gap-3 mb-4">
-      <div className="w-8 h-8 rounded-full bg-gray-500 flex items-center justify-center flex-shrink-0">
-        <MessageCircle size={16} className="text-white" />
-      </div>
-      <div className="bg-gray-200 rounded-2xl rounded-bl-md px-4 py-3">
-        <div className="flex gap-1">
-          <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce"></div>
-          <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }}></div>
-          <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></div>
-        </div>
-      </div>
-    </div>
-  );
-}
+import { User, Mic, MicOff, X } from "react-feather";
 
 export default function ChatInterface({ 
-  events = [], 
-  sendTextMessage, 
   isSessionActive,
-  isTyping = false,
   isMuted = false,
   toggleMute,
-  isListening = false,
-  isSpeaking = false,
-  audioLevel = 0
+  personaSettings = {},
+  sceneSettings = {},
+  purpose = "",
+  onStopSession
 }) {
-  const [message, setMessage] = useState("");
-  const messagesEndRef = useRef(null);
-  const inputRef = useRef(null);
-
-  // Auto-scroll to bottom when new messages arrive
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  };
-
-  useEffect(() => {
-    scrollToBottom();
-  }, [events, isTyping]);
-
-  // Convert events to chat messages
-  const messages = events
-    .filter(event => 
-      (event.type === 'conversation.item.create' && event.item?.content) ||
-      (event.type === 'response.done' && event.response?.output)
-    )
-    .map(event => {
-      if (event.type === 'conversation.item.create' && event.item?.content) {
-        const content = event.item.content[0];
-        return {
-          id: event.event_id || crypto.randomUUID(),
-          message: content.text || content.input_text || 'Message sent',
-          isUser: event.item.role === 'user',
-          timestamp: event.timestamp
-        };
-      } else if (event.type === 'response.done' && event.response?.output) {
-        const textOutputs = event.response.output
-          .filter(output => output.type === 'message' && output.content)
-          .map(output => output.content
-            .filter(content => content.type === 'text')
-            .map(content => content.text)
-            .join(' ')
-          )
-          .filter(text => text.length > 0);
-        
-        return textOutputs.map(text => ({
-          id: event.event_id + '_' + crypto.randomUUID(),
-          message: text,
-          isUser: false,
-          timestamp: event.timestamp
-        }));
-      }
-      return null;
-    })
-    .flat()
-    .filter(Boolean)
-    .reverse(); // Show newest messages at bottom
-
-  const handleSendMessage = () => {
-    if (!message.trim() || !isSessionActive) return;
-    
-    sendTextMessage(message);
-    setMessage("");
-    
-    // Focus back to input after sending
-    setTimeout(() => {
-      inputRef.current?.focus();
-    }, 100);
-  };
-
-  const handleKeyPress = (e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSendMessage();
-    }
-  };
 
   if (!isSessionActive) {
     return (
       <div className="flex-1 flex flex-col items-center justify-center p-8 text-center">
         <div className="w-32 h-32 rounded-full bg-gray-100 flex items-center justify-center mb-6">
-          <MessageCircle size={48} className="text-gray-400" />
+          <User size={48} className="text-gray-400" />
         </div>
-        <h2 className="text-2xl font-bold text-gray-800 mb-2">チャット停止中</h2>
-        <p className="text-gray-600">セッションを開始してチャットを始めましょう</p>
+        <h2 className="text-2xl font-bold text-gray-800 mb-2">ロールプレイ停止中</h2>
+        <p className="text-gray-600">セッションを開始してロールプレイを始めましょう</p>
       </div>
     );
   }
 
   return (
-    <div className="flex-1 flex flex-col h-full bg-white">
-      {/* Chat header */}
-      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex-shrink-0">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className={`w-8 h-8 rounded-full flex items-center justify-center ${
-              isSessionActive ? 'bg-green-500' : 'bg-gray-400'
-            }`}>
-              <MessageCircle size={16} className="text-white" />
-            </div>
-            <div>
-              <h3 className="font-semibold text-gray-800">AIアシスタント</h3>
-              <p className={`text-xs ${isSessionActive ? 'text-green-600' : 'text-gray-500'}`}>
-                {isSessionActive ? 'オンライン' : 'オフライン'}
-              </p>
-            </div>
-          </div>
-          
-          {/* Mute button - only show when session is active */}
-          {isSessionActive && (
-            <button
-              onClick={toggleMute}
-              className={`p-2 rounded-full transition-colors ${
-                isMuted 
-                  ? 'bg-red-100 hover:bg-red-200 text-red-600' 
-                  : 'bg-green-100 hover:bg-green-200 text-green-600'
-              }`}
-              title={isMuted ? 'ミュート中 - クリックでミュート解除' : 'マイクオン - クリックでミュート'}
-            >
-              {isMuted ? <MicOff size={18} /> : <Mic size={18} />}
-            </button>
-          )}
-        </div>
+    <div className="flex-1 flex flex-col h-full bg-gray-50">
+      {/* Control Bar */}
+      <div className="bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between flex-shrink-0">
+        {/* Left side - Mute button */}
+        <button
+          onClick={toggleMute}
+          className={`p-3 rounded-full transition-colors ${
+            isMuted 
+              ? 'bg-red-100 hover:bg-red-200 text-red-600' 
+              : 'bg-green-100 hover:bg-green-200 text-green-600'
+          }`}
+          title={isMuted ? 'ミュート中 - クリックでミュート解除' : 'マイクオン - クリックでミュート'}
+        >
+          {isMuted ? <MicOff size={20} /> : <Mic size={20} />}
+        </button>
+
+        {/* Right side - End session button */}
+        <button
+          onClick={onStopSession}
+          className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors"
+          title="ロールプレイを終了して準備画面に戻る"
+        >
+          <X size={16} />
+          <span>終了</span>
+        </button>
       </div>
 
-      {/* Messages area - with responsive padding for desktop tool panel */}
-      <div className="flex-1 overflow-y-auto p-3 sm:p-4 xl:pr-[340px] space-y-2 pb-32 sm:pb-28 relative">
+      {/* Main content area */}
+      <div className="flex-1 flex flex-col items-center justify-center p-6 space-y-8">
+        
+        {/* Persona Image */}
+        <div className="w-48 h-48 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center shadow-lg">
+          <User size={80} className="text-white" />
+        </div>
+
+        {/* Roleplay Meta Information */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 max-w-md w-full">
+          <h3 className="text-lg font-semibold text-gray-800 mb-4 text-center">ロールプレイ情報</h3>
+          
+          {/* Purpose */}
+          {purpose && (
+            <div className="mb-4">
+              <h4 className="text-sm font-medium text-gray-600 mb-1">目的</h4>
+              <p className="text-gray-800">{purpose}</p>
+            </div>
+          )}
+
+          {/* Persona Information */}
+          <div className="mb-4">
+            <h4 className="text-sm font-medium text-gray-600 mb-2">ペルソナ</h4>
+            <div className="space-y-1 text-sm text-gray-700">
+              {personaSettings.age && <p><span className="font-medium">年齢:</span> {personaSettings.age}</p>}
+              {personaSettings.gender && <p><span className="font-medium">性別:</span> {personaSettings.gender}</p>}
+              {personaSettings.occupation && <p><span className="font-medium">職業:</span> {personaSettings.occupation}</p>}
+              {personaSettings.personality && <p><span className="font-medium">性格:</span> {personaSettings.personality}</p>}
+              {personaSettings.additionalInfo && <p><span className="font-medium">追加情報:</span> {personaSettings.additionalInfo}</p>}
+              {!personaSettings.age && !personaSettings.gender && !personaSettings.occupation && !personaSettings.personality && !personaSettings.additionalInfo && (
+                <p className="text-gray-500 italic">設定なし</p>
+              )}
+            </div>
+          </div>
+
+          {/* Scene Information */}
+          <div>
+            <h4 className="text-sm font-medium text-gray-600 mb-2">シーン設定</h4>
+            <div className="space-y-1 text-sm text-gray-700">
+              {sceneSettings.appointmentBackground && <p><span className="font-medium">背景:</span> {sceneSettings.appointmentBackground}</p>}
+              {sceneSettings.relationship && <p><span className="font-medium">関係性:</span> {sceneSettings.relationship}</p>}
+              {sceneSettings.timeOfDay && <p><span className="font-medium">時間帯:</span> {sceneSettings.timeOfDay}</p>}
+              {sceneSettings.location && <p><span className="font-medium">場所:</span> {sceneSettings.location}</p>}
+              {sceneSettings.additionalInfo && <p><span className="font-medium">追加情報:</span> {sceneSettings.additionalInfo}</p>}
+              {!sceneSettings.appointmentBackground && !sceneSettings.relationship && !sceneSettings.timeOfDay && !sceneSettings.location && !sceneSettings.additionalInfo && (
+                <p className="text-gray-500 italic">設定なし</p>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Status Indicator */}
+        <div className="flex items-center gap-3 bg-white rounded-full px-6 py-3 shadow-sm border border-gray-200">
+          <div className="w-3 h-3 bg-green-500 rounded-full animate-pulse"></div>
+          <span className="text-sm font-medium text-gray-700">ロールプレイ実行中</span>
+        </div>
+
         {/* Mute status overlay */}
         {isMuted && (
           <div className="fixed top-20 left-1/2 transform -translate-x-1/2 bg-red-500 text-white px-4 py-2 rounded-full shadow-lg z-20 flex items-center gap-2">
@@ -188,60 +114,6 @@ export default function ChatInterface({
             <span className="text-sm font-medium">マイクミュート中</span>
           </div>
         )}
-        
-        {messages.length === 0 ? (
-          <div className="text-center py-8">
-            <p className="text-gray-500 mb-2">まだメッセージがありません</p>
-            <p className="text-sm text-gray-400">メッセージを送信して会話を始めましょう</p>
-          </div>
-        ) : (
-          messages.map((msg) => (
-            <MessageBubble
-              key={msg.id}
-              message={msg.message}
-              isUser={msg.isUser}
-              timestamp={msg.timestamp}
-            />
-          ))
-        )}
-        
-        {isTyping && <TypingIndicator />}
-        <div ref={messagesEndRef} />
-      </div>
-
-      {/* Input area - Fixed at bottom with responsive padding */}
-      <div className="fixed bottom-14 sm:bottom-16 left-0 right-0 xl:right-[320px] border-t border-gray-200 p-3 sm:p-4 bg-white z-10 safe-area-inset-bottom">
-        <div className="flex gap-2 items-end max-w-4xl mx-auto">
-          <div className="flex-1 min-w-0">
-            <textarea
-              ref={inputRef}
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-              onKeyDown={handleKeyPress}
-              placeholder="メッセージを入力..."
-              className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-2xl resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm overflow-hidden"
-              rows={1}
-              style={{ 
-                minHeight: '40px', 
-                maxHeight: '120px',
-                lineHeight: '1.5',
-                wordWrap: 'break-word',
-                overflowWrap: 'break-word'
-              }}
-            />
-          </div>
-          <button
-            onClick={handleSendMessage}
-            disabled={!message.trim()}
-            className={`p-2.5 sm:p-3 rounded-full min-h-[40px] min-w-[40px] sm:min-h-[44px] sm:min-w-[44px] flex items-center justify-center transition-colors flex-shrink-0 ${
-              message.trim()
-                ? 'bg-blue-500 hover:bg-blue-600 text-white'
-                : 'bg-gray-200 text-gray-400 cursor-not-allowed'
-            }`}
-          >
-            <Send size={16} className="sm:w-[18px] sm:h-[18px]" />
-          </button>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Simplifies the roleplay screen to display only the required elements as requested in issue #86:

- Persona image (gradient placeholder)
- Roleplay meta information (purpose, persona, scene settings)
- Mute button
- End session button that returns to setup screen

Removes:
- Chat messages and history
- Message input area
- All other unnecessary UI elements

Resolves #86

Generated with [Claude Code](https://claude.ai/code)