### PR TITLE
スマホ対応のUI修正

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -317,10 +317,10 @@ export default function App() {
   return (
     <div className="h-screen bg-gray-50 flex flex-col overflow-hidden">
       {/* Header */}
-      <nav className="bg-white border-b border-gray-200 px-3 sm:px-4 py-3 flex-shrink-0 z-20">
-        <div className="flex items-center justify-between">
+      <nav className="bg-white border-b border-gray-200 px-2 sm:px-4 py-2 sm:py-3 flex-shrink-0 z-20">
+        <div className="flex items-center justify-between h-12 sm:h-auto">
           <div className="flex items-center gap-2 sm:gap-3 min-w-0">
-            <img style={{ width: "20px" }} className="sm:w-6 flex-shrink-0" src={logo} alt="OpenAI Logo" />
+            <img style={{ width: "18px" }} className="sm:w-6 flex-shrink-0" src={logo} alt="OpenAI Logo" />
             <div className="min-w-0">
               <h1 className="text-sm sm:text-base font-semibold text-gray-800 truncate">Realtime Console</h1>
               <p className="text-xs text-gray-500 hidden sm:block">Mobile Edition</p>
@@ -329,10 +329,10 @@ export default function App() {
           
           <div className="flex items-center gap-1 sm:gap-3 flex-shrink-0">
             {/* User info - hide on very small screens */}
-            <span className="hidden xs:block text-xs text-gray-600 truncate max-w-20 sm:max-w-none">{currentUser}</span>
+            <span className="hidden xs:block text-xs text-gray-600 truncate max-w-16 sm:max-w-none">{currentUser}</span>
             
             {/* Session status indicator */}
-            <div className={`px-1 sm:px-2 py-1 rounded-full text-xs font-medium ${
+            <div className={`px-1.5 sm:px-2 py-1 rounded-full text-xs font-medium ${
               isSessionActive 
                 ? 'bg-green-100 text-green-700' 
                 : 'bg-gray-100 text-gray-600'
@@ -344,7 +344,7 @@ export default function App() {
             {/* Logout button */}
             <button
               onClick={handleLogout}
-              className="text-xs text-gray-500 hover:text-gray-700 px-1 sm:px-2 py-1 rounded hover:bg-gray-100 flex-shrink-0"
+              className="text-xs text-gray-500 hover:text-gray-700 px-1.5 sm:px-2 py-1 rounded hover:bg-gray-100 flex-shrink-0"
             >
               <span className="hidden sm:inline">ログアウト</span>
               <span className="sm:hidden">出</span>

--- a/client/components/ChatInterface.jsx
+++ b/client/components/ChatInterface.jsx
@@ -25,55 +25,55 @@ export default function ChatInterface({
   return (
     <div className="flex-1 flex flex-col h-full bg-gray-50">
       {/* Control Bar */}
-      <div className="bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between flex-shrink-0">
+      <div className="bg-white border-b border-gray-200 px-3 sm:px-4 py-2 sm:py-3 flex items-center justify-between flex-shrink-0">
         {/* Left side - Mute button */}
         <button
           onClick={toggleMute}
-          className={`p-3 rounded-full transition-colors ${
+          className={`p-2.5 sm:p-3 rounded-full transition-colors ${
             isMuted 
               ? 'bg-red-100 hover:bg-red-200 text-red-600' 
               : 'bg-green-100 hover:bg-green-200 text-green-600'
           }`}
           title={isMuted ? 'ミュート中 - クリックでミュート解除' : 'マイクオン - クリックでミュート'}
         >
-          {isMuted ? <MicOff size={20} /> : <Mic size={20} />}
+          {isMuted ? <MicOff size={18} className="sm:size-5" /> : <Mic size={18} className="sm:size-5" />}
         </button>
 
         {/* Right side - End session button */}
         <button
           onClick={onStopSession}
-          className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-lg flex items-center gap-2 transition-colors"
+          className="bg-red-500 hover:bg-red-600 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg flex items-center gap-1.5 sm:gap-2 transition-colors text-sm sm:text-base"
           title="ロールプレイを終了して準備画面に戻る"
         >
-          <X size={16} />
+          <X size={14} className="sm:size-4" />
           <span>終了</span>
         </button>
       </div>
 
       {/* Main content area */}
-      <div className="flex-1 flex flex-col items-center justify-center p-6 space-y-8">
+      <div className="flex-1 flex flex-col items-center justify-center p-3 sm:p-6 space-y-4 sm:space-y-8">
         
         {/* Persona Image */}
-        <div className="w-48 h-48 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center shadow-lg">
-          <User size={80} className="text-white" />
+        <div className="w-32 h-32 sm:w-48 sm:h-48 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center shadow-lg">
+          <User size={48} className="sm:size-20 text-white" />
         </div>
 
         {/* Roleplay Meta Information */}
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 max-w-md w-full">
-          <h3 className="text-lg font-semibold text-gray-800 mb-4 text-center">ロールプレイ情報</h3>
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-3 sm:p-6 max-w-md w-full">
+          <h3 className="text-base sm:text-lg font-semibold text-gray-800 mb-3 sm:mb-4 text-center">ロールプレイ情報</h3>
           
           {/* Purpose */}
           {purpose && (
-            <div className="mb-4">
-              <h4 className="text-sm font-medium text-gray-600 mb-1">目的</h4>
-              <p className="text-gray-800">{purpose}</p>
+            <div className="mb-3 sm:mb-4">
+              <h4 className="text-xs sm:text-sm font-medium text-gray-600 mb-1">目的</h4>
+              <p className="text-sm sm:text-base text-gray-800">{purpose}</p>
             </div>
           )}
 
           {/* Persona Information */}
-          <div className="mb-4">
-            <h4 className="text-sm font-medium text-gray-600 mb-2">ペルソナ</h4>
-            <div className="space-y-1 text-sm text-gray-700">
+          <div className="mb-3 sm:mb-4">
+            <h4 className="text-xs sm:text-sm font-medium text-gray-600 mb-1.5 sm:mb-2">ペルソナ</h4>
+            <div className="space-y-0.5 sm:space-y-1 text-xs sm:text-sm text-gray-700">
               {personaSettings.age && <p><span className="font-medium">年齢:</span> {personaSettings.age}</p>}
               {personaSettings.gender && <p><span className="font-medium">性別:</span> {personaSettings.gender}</p>}
               {personaSettings.occupation && <p><span className="font-medium">職業:</span> {personaSettings.occupation}</p>}
@@ -87,8 +87,8 @@ export default function ChatInterface({
 
           {/* Scene Information */}
           <div>
-            <h4 className="text-sm font-medium text-gray-600 mb-2">シーン設定</h4>
-            <div className="space-y-1 text-sm text-gray-700">
+            <h4 className="text-xs sm:text-sm font-medium text-gray-600 mb-1.5 sm:mb-2">シーン設定</h4>
+            <div className="space-y-0.5 sm:space-y-1 text-xs sm:text-sm text-gray-700">
               {sceneSettings.appointmentBackground && <p><span className="font-medium">背景:</span> {sceneSettings.appointmentBackground}</p>}
               {sceneSettings.relationship && <p><span className="font-medium">関係性:</span> {sceneSettings.relationship}</p>}
               {sceneSettings.timeOfDay && <p><span className="font-medium">時間帯:</span> {sceneSettings.timeOfDay}</p>}
@@ -102,16 +102,16 @@ export default function ChatInterface({
         </div>
 
         {/* Status Indicator */}
-        <div className="flex items-center gap-3 bg-white rounded-full px-6 py-3 shadow-sm border border-gray-200">
-          <div className="w-3 h-3 bg-green-500 rounded-full animate-pulse"></div>
-          <span className="text-sm font-medium text-gray-700">ロールプレイ実行中</span>
+        <div className="flex items-center gap-2 sm:gap-3 bg-white rounded-full px-4 sm:px-6 py-2 sm:py-3 shadow-sm border border-gray-200">
+          <div className="w-2.5 h-2.5 sm:w-3 sm:h-3 bg-green-500 rounded-full animate-pulse"></div>
+          <span className="text-xs sm:text-sm font-medium text-gray-700">ロールプレイ実行中</span>
         </div>
 
         {/* Mute status overlay */}
         {isMuted && (
-          <div className="fixed top-20 left-1/2 transform -translate-x-1/2 bg-red-500 text-white px-4 py-2 rounded-full shadow-lg z-20 flex items-center gap-2">
-            <MicOff size={16} />
-            <span className="text-sm font-medium">マイクミュート中</span>
+          <div className="fixed top-16 sm:top-20 left-1/2 transform -translate-x-1/2 bg-red-500 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-full shadow-lg z-20 flex items-center gap-1.5 sm:gap-2">
+            <MicOff size={14} className="sm:size-4" />
+            <span className="text-xs sm:text-sm font-medium">マイクミュート中</span>
           </div>
         )}
       </div>

--- a/client/components/SetupScreen.jsx
+++ b/client/components/SetupScreen.jsx
@@ -13,21 +13,21 @@ function ExpandableSection({ title, children, defaultExpanded = false, icon: Ico
     <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full p-3 sm:p-4 flex items-center justify-between text-left hover:bg-gray-50 transition-colors"
+        className="w-full p-2.5 sm:p-4 flex items-center justify-between text-left hover:bg-gray-50 transition-colors"
       >
-        <div className="flex items-center gap-3">
-          {Icon && <Icon size={20} className="text-gray-600" />}
-          <h3 className="font-semibold text-gray-800">{title}</h3>
+        <div className="flex items-center gap-2 sm:gap-3">
+          {Icon && <Icon size={18} className="sm:size-5 text-gray-600" />}
+          <h3 className="text-sm sm:text-base font-semibold text-gray-800">{title}</h3>
         </div>
         {isExpanded ? (
-          <ChevronUp size={20} className="text-gray-400" />
+          <ChevronUp size={18} className="sm:size-5 text-gray-400" />
         ) : (
-          <ChevronDown size={20} className="text-gray-400" />
+          <ChevronDown size={18} className="sm:size-5 text-gray-400" />
         )}
       </button>
       
       {isExpanded && (
-        <div className="px-3 sm:px-4 pb-3 sm:pb-4 border-t border-gray-100">
+        <div className="px-2.5 sm:px-4 pb-2.5 sm:pb-4 border-t border-gray-100">
           {children}
         </div>
       )}
@@ -191,14 +191,14 @@ export default function SetupScreen({
 
 
   return (
-    <div className="flex-1 overflow-y-auto p-3 sm:p-4 xl:pr-[340px] bg-gray-50">
-      <div className="max-w-md mx-auto space-y-3 sm:space-y-4 pb-20 safe-area-inset-bottom">
-        {/* Header */}
-        <div className="text-center py-6">
-          <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
-            <Settings size={32} className="text-blue-600" />
+    <div className="flex-1 overflow-y-auto p-2 sm:p-4 xl:pr-[340px] bg-gray-50">
+      <div className="max-w-md mx-auto space-y-2 sm:space-y-4 pb-20 safe-area-inset-bottom">
+        {/* Header - Compact for mobile */}
+        <div className="text-center py-3 sm:py-6">
+          <div className="w-12 h-12 sm:w-16 sm:h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-2 sm:mb-4">
+            <Settings size={20} className="sm:size-8 text-blue-600" />
           </div>
-          <h1 className="text-2xl font-bold text-gray-800 mb-2">AIロールプレイング</h1>
+          <h1 className="text-xl sm:text-2xl font-bold text-gray-800 mb-1 sm:mb-2">AIロールプレイング</h1>
         </div>
 
         {/* Mode Toggle */}
@@ -238,15 +238,15 @@ export default function SetupScreen({
             {/* 既存のカスタム設定UI */}
 
         {/* Purpose Setting */}
-        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-3 sm:p-4">
-          <div className="flex items-center gap-3 mb-3">
-            <h2 className="text-base sm:text-lg font-semibold text-gray-800">目的</h2>
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-2.5 sm:p-4">
+          <div className="flex items-center gap-2 mb-2 sm:mb-3">
+            <h2 className="text-sm sm:text-lg font-semibold text-gray-800">目的</h2>
           </div>
           <textarea
             value={purpose}
             onChange={(e) => setPurpose(e.target.value)}
             placeholder="例: マンション購入契約、雑談、プレゼンテーションの練習など"
-            className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             rows={2}
           />
         </div>
@@ -257,15 +257,15 @@ export default function SetupScreen({
           defaultExpanded={false}
           icon={User}
         >
-          <div className="pt-3 space-y-4">
+          <div className="pt-2 sm:pt-3 space-y-3 sm:space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5 sm:mb-2">
                 年齢
               </label>
               <select
                 value={personaSettings.age}
                 onChange={(e) => setPersonaSettings({...personaSettings, age: e.target.value})}
-                className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               >
                 <option value="">選択してください</option>
                 <option value="20代前半">20代前半</option>
@@ -282,13 +282,13 @@ export default function SetupScreen({
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5 sm:mb-2">
                 性別
               </label>
               <select
                 value={personaSettings.gender}
                 onChange={(e) => setPersonaSettings({...personaSettings, gender: e.target.value})}
-                className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               >
                 <option value="">選択してください</option>
                 <option value="男性">男性</option>
@@ -298,7 +298,7 @@ export default function SetupScreen({
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5 sm:mb-2">
                 職業
               </label>
               <input
@@ -306,32 +306,32 @@ export default function SetupScreen({
                 value={personaSettings.occupation}
                 onChange={(e) => setPersonaSettings({...personaSettings, occupation: e.target.value})}
                 placeholder="例: エンジニア、医師、教師など"
-                className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5 sm:mb-2">
                 パーソナリティ
               </label>
               <textarea
                 value={personaSettings.personality}
                 onChange={(e) => setPersonaSettings({...personaSettings, personality: e.target.value})}
                 placeholder="例: 明るく親しみやすい、論理的で分析的、優しく思いやりがあるなど"
-                className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 rows={3}
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5 sm:mb-2">
                 追加情報
               </label>
               <textarea
                 value={personaSettings.additionalInfo}
                 onChange={(e) => setPersonaSettings({...personaSettings, additionalInfo: e.target.value})}
                 placeholder="その他の特徴や詳細情報があれば入力してください"
-                className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 rows={2}
               />
             </div>
@@ -344,22 +344,22 @@ export default function SetupScreen({
           defaultExpanded={false}
           icon={MapPin}
         >
-          <div className="pt-3 space-y-4">
+          <div className="pt-2 sm:pt-3 space-y-3 sm:space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5 sm:mb-2">
                 アポイントメントの背景
               </label>
               <textarea
                 value={sceneSettings.appointmentBackground}
                 onChange={(e) => setSceneSettings({...sceneSettings, appointmentBackground: e.target.value})}
                 placeholder="例: 新商品の打ち合わせ、健康診断、面接など"
-                className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 rows={2}
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5 sm:mb-2">
                 相手との関係性
               </label>
               <input
@@ -367,18 +367,18 @@ export default function SetupScreen({
                 value={sceneSettings.relationship}
                 onChange={(e) => setSceneSettings({...sceneSettings, relationship: e.target.value})}
                 placeholder="例: 同僚、友人、初対面、上司など"
-                className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5 sm:mb-2">
                 時間帯
               </label>
               <select
                 value={sceneSettings.timeOfDay}
                 onChange={(e) => setSceneSettings({...sceneSettings, timeOfDay: e.target.value})}
-                className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               >
                 <option value="">選択してください</option>
                 <option value="朝">朝</option>
@@ -391,7 +391,7 @@ export default function SetupScreen({
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5 sm:mb-2">
                 場所
               </label>
               <input
@@ -399,19 +399,19 @@ export default function SetupScreen({
                 value={sceneSettings.location}
                 onChange={(e) => setSceneSettings({...sceneSettings, location: e.target.value})}
                 placeholder="例: オフィス、カフェ、病院、自宅など"
-                className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
+              <label className="block text-xs sm:text-sm font-medium text-gray-700 mb-1.5 sm:mb-2">
                 追加情報
               </label>
               <textarea
                 value={sceneSettings.additionalInfo}
                 onChange={(e) => setSceneSettings({...sceneSettings, additionalInfo: e.target.value})}
                 placeholder="シーンに関する追加情報があれば入力してください"
-                className="w-full p-2.5 sm:p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 rows={2}
               />
             </div>
@@ -420,16 +420,16 @@ export default function SetupScreen({
 
 
             {/* Generate Prompt Button */}
-            <div className="pt-6">
+            <div className="pt-4 sm:pt-6">
               <Button
                 onClick={handleGeneratePrompt}
                 disabled={isStarting}
-                className={`w-full py-4 text-base font-semibold ${
+                className={`w-full py-3 sm:py-4 text-sm sm:text-base font-semibold ${
                   isStarting 
                     ? 'bg-gray-400 cursor-not-allowed' 
                     : 'bg-green-600 hover:bg-green-700'
                 }`}
-                icon={<Play size={20} />}
+                icon={<Play size={18} className="sm:size-5" />}
               >
                 {isStarting ? 'プロンプト生成中...' : 'ロープレ開始'}
               </Button>


### PR DESCRIPTION
スマホでのUI崩れを修正し、スクロールが不要になるよう調整しました。

## 修正内容
- ヘッダーレイアウトを小画面用に最適化
- SetupScreenのフォームをよりコンパクトに
- ChatInterfaceのペルソナ画像と情報カードサイズをモバイル向けに縮小
- モバイルデバイスでスクロール不要を実現

Fixes #88

🤖 Generated with [Claude Code](https://claude.ai/code)