### PR TITLE
feat: ペルソナ画像下部にミュートボタンとロープレ終了ボタンを配置

### DIFF
--- a/client/components/ChatInterface.jsx
+++ b/client/components/ChatInterface.jsx
@@ -32,32 +32,6 @@ export default function ChatInterface({
           <User size={48} className="sm:size-20 text-white" />
         </div>
 
-        {/* Control Buttons below Persona Image */}
-        <div className="flex items-center gap-3 sm:gap-4">
-          {/* Mute button */}
-          <button
-            onClick={toggleMute}
-            className={`p-2.5 sm:p-3 rounded-full transition-colors ${
-              isMuted 
-                ? 'bg-red-100 hover:bg-red-200 text-red-600' 
-                : 'bg-green-100 hover:bg-green-200 text-green-600'
-            }`}
-            title={isMuted ? 'ミュート中 - クリックでミュート解除' : 'マイクオン - クリックでミュート'}
-          >
-            {isMuted ? <MicOff size={18} className="sm:size-5" /> : <Mic size={18} className="sm:size-5" />}
-          </button>
-
-          {/* End session button */}
-          <button
-            onClick={onStopSession}
-            className="bg-red-500 hover:bg-red-600 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg flex items-center gap-1.5 sm:gap-2 transition-colors text-sm sm:text-base"
-            title="ロールプレイを終了して準備画面に戻る"
-          >
-            <X size={14} className="sm:size-4" />
-            <span>終了</span>
-          </button>
-        </div>
-
         {/* Roleplay Meta Information */}
         <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-3 sm:p-6 max-w-md w-full">
           <h3 className="text-base sm:text-lg font-semibold text-gray-800 mb-3 sm:mb-4 text-center">ロールプレイ情報</h3>
@@ -99,6 +73,32 @@ export default function ChatInterface({
               )}
             </div>
           </div>
+        </div>
+
+        {/* Control Buttons below Meta Information */}
+        <div className="flex items-center gap-4 sm:gap-6">
+          {/* Mute button */}
+          <button
+            onClick={toggleMute}
+            className={`p-4 sm:p-5 rounded-full transition-all duration-200 shadow-lg ${
+              isMuted 
+                ? 'bg-red-500 hover:bg-red-600 text-white shadow-red-200' 
+                : 'bg-green-500 hover:bg-green-600 text-white shadow-green-200'
+            }`}
+            title={isMuted ? 'ミュート中 - クリックでミュート解除' : 'マイクオン - クリックでミュート'}
+          >
+            {isMuted ? <MicOff size={24} className="sm:size-7" /> : <Mic size={24} className="sm:size-7" />}
+          </button>
+
+          {/* End session button */}
+          <button
+            onClick={onStopSession}
+            className="bg-red-500 hover:bg-red-600 text-white px-6 sm:px-8 py-3 sm:py-4 rounded-full flex items-center gap-2 sm:gap-3 transition-all duration-200 text-base sm:text-lg font-medium shadow-lg shadow-red-200"
+            title="ロールプレイを終了して準備画面に戻る"
+          >
+            <X size={20} className="sm:size-6" />
+            <span>終了</span>
+          </button>
         </div>
 
         {/* Status Indicator */}

--- a/client/components/ChatInterface.jsx
+++ b/client/components/ChatInterface.jsx
@@ -24,38 +24,38 @@ export default function ChatInterface({
 
   return (
     <div className="flex-1 flex flex-col h-full bg-gray-50">
-      {/* Control Bar */}
-      <div className="bg-white border-b border-gray-200 px-3 sm:px-4 py-2 sm:py-3 flex items-center justify-between flex-shrink-0">
-        {/* Left side - Mute button */}
-        <button
-          onClick={toggleMute}
-          className={`p-2.5 sm:p-3 rounded-full transition-colors ${
-            isMuted 
-              ? 'bg-red-100 hover:bg-red-200 text-red-600' 
-              : 'bg-green-100 hover:bg-green-200 text-green-600'
-          }`}
-          title={isMuted ? 'ミュート中 - クリックでミュート解除' : 'マイクオン - クリックでミュート'}
-        >
-          {isMuted ? <MicOff size={18} className="sm:size-5" /> : <Mic size={18} className="sm:size-5" />}
-        </button>
-
-        {/* Right side - End session button */}
-        <button
-          onClick={onStopSession}
-          className="bg-red-500 hover:bg-red-600 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg flex items-center gap-1.5 sm:gap-2 transition-colors text-sm sm:text-base"
-          title="ロールプレイを終了して準備画面に戻る"
-        >
-          <X size={14} className="sm:size-4" />
-          <span>終了</span>
-        </button>
-      </div>
-
       {/* Main content area */}
       <div className="flex-1 flex flex-col items-center justify-center p-3 sm:p-6 space-y-4 sm:space-y-8">
         
         {/* Persona Image */}
         <div className="w-32 h-32 sm:w-48 sm:h-48 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center shadow-lg">
           <User size={48} className="sm:size-20 text-white" />
+        </div>
+
+        {/* Control Buttons below Persona Image */}
+        <div className="flex items-center gap-3 sm:gap-4">
+          {/* Mute button */}
+          <button
+            onClick={toggleMute}
+            className={`p-2.5 sm:p-3 rounded-full transition-colors ${
+              isMuted 
+                ? 'bg-red-100 hover:bg-red-200 text-red-600' 
+                : 'bg-green-100 hover:bg-green-200 text-green-600'
+            }`}
+            title={isMuted ? 'ミュート中 - クリックでミュート解除' : 'マイクオン - クリックでミュート'}
+          >
+            {isMuted ? <MicOff size={18} className="sm:size-5" /> : <Mic size={18} className="sm:size-5" />}
+          </button>
+
+          {/* End session button */}
+          <button
+            onClick={onStopSession}
+            className="bg-red-500 hover:bg-red-600 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg flex items-center gap-1.5 sm:gap-2 transition-colors text-sm sm:text-base"
+            title="ロールプレイを終了して準備画面に戻る"
+          >
+            <X size={14} className="sm:size-4" />
+            <span>終了</span>
+          </button>
         </div>
 
         {/* Roleplay Meta Information */}


### PR DESCRIPTION
Issue #90の対応:ペルソナ画像下部にミュートボタンとロープレ終了ボタンを配置

## 変更内容
- ChatInterface.jsxでコントロールバーを削除
- ペルソナ画像の直下にミュートボタンと終了ボタンを水平配置
- UIの使いやすさを向上させるレイアウト変更

## テスト
- ミュート機能が正常に動作することを確認
- ロープレ終了機能が正常に動作することを確認
- レスポンシブデザインが正常に機能することを確認

Generated with [Claude Code](https://claude.ai/code)