### PR TITLE
UI微調整: OpenAIロゴと微調整ボタンを削除

### DIFF
--- a/client/components/LoginScreen.jsx
+++ b/client/components/LoginScreen.jsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import logo from "../assets/openai-logomark.svg";
 import { login } from "../utils/auth.js";
 
 export default function LoginScreen({ onLogin }) {
@@ -34,11 +33,6 @@ export default function LoginScreen({ onLogin }) {
         <div className="bg-white rounded-lg shadow-md p-8">
           {/* Header */}
           <div className="text-center mb-8">
-            <img 
-              src={logo} 
-              alt="OpenAI Logo" 
-              className="w-12 h-12 mx-auto mb-4"
-            />
             <h1 className="text-2xl font-bold text-gray-900">Realtime Console</h1>
             <p className="text-gray-600 mt-2">認証が必要です</p>
           </div>

--- a/client/components/PresetSelector.jsx
+++ b/client/components/PresetSelector.jsx
@@ -92,13 +92,6 @@ export default function PresetSelector({
               このプリセットで開始
             </Button>
             
-            <Button
-              onClick={handleCustomizeClick}
-              className="w-full py-3 text-sm bg-gray-100 hover:bg-gray-200 text-gray-700"
-              icon={<Edit3 size={16} />}
-            >
-              微調整してから開始
-            </Button>
           </div>
         )}
 
@@ -231,13 +224,6 @@ export default function PresetSelector({
             このプリセットで開始
           </Button>
           
-          <Button
-            onClick={handleCustomizeClick}
-            className="w-full py-3 text-sm bg-gray-100 hover:bg-gray-200 text-gray-700"
-            icon={<Edit3 size={16} />}
-          >
-            微調整してから開始
-          </Button>
         </div>
       )}
     </div>


### PR DESCRIPTION
ログイン画面からOpenAIロゴを削除し、プリセット選択画面から「微調整してから開始」ボタンを削除しました。

Closes #98

Generated with [Claude Code](https://claude.ai/code)