### PR TITLE
feat: 管理職ダッシュボードのデモページ作成

### DIFF
--- a/client/components/AdminDashboard.jsx
+++ b/client/components/AdminDashboard.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Users, BookOpen, TrendingUp, Clock, Star, BarChart3 } from "react-feather";
+import { Users, BookOpen, TrendingUp, Clock, Star, BarChart } from "react-feather";
 import { Link, useNavigate } from "react-router-dom";
 
 // Mock data for dashboard
@@ -58,7 +58,7 @@ export default function AdminDashboard() {
   const navigate = useNavigate();
 
   const tabs = [
-    { id: "overview", label: "組織全体俯瞰", icon: BarChart3 },
+    { id: "overview", label: "組織全体俯瞰", icon: BarChart },
     { id: "departments", label: "部門別分析", icon: Users },
     { id: "courses", label: "コース管理", icon: BookOpen }
   ];

--- a/client/components/AdminDashboard.jsx
+++ b/client/components/AdminDashboard.jsx
@@ -1,0 +1,304 @@
+import { useState } from "react";
+import { Users, BookOpen, TrendingUp, Clock, Star, BarChart3 } from "react-feather";
+import { Link, useNavigate } from "react-router-dom";
+
+// Mock data for dashboard
+const mockData = {
+  overallStats: {
+    totalEmployees: 247,
+    activeUsers: 189,
+    completionRate: 74,
+    averageScore: 8.2,
+    totalLearningHours: 1256,
+    coursesCompleted: 342
+  },
+  departmentStats: [
+    { id: 1, name: "営業部", members: 45, completionRate: 82, avgScore: 8.7, activeLearners: 38 },
+    { id: 2, name: "開発部", members: 32, completionRate: 91, avgScore: 9.1, activeLearners: 31 },
+    { id: 3, name: "マーケティング部", members: 28, completionRate: 76, avgScore: 8.3, activeLearners: 22 },
+    { id: 4, name: "人事部", members: 15, completionRate: 68, avgScore: 7.9, activeLearners: 12 },
+    { id: 5, name: "総務部", members: 18, completionRate: 59, avgScore: 7.4, activeLearners: 11 }
+  ],
+  topPerformers: [
+    { id: 1, name: "田中 太郎", department: "開発部", score: 9.8, hours: 45, courses: 12 },
+    { id: 2, name: "佐藤 花子", department: "営業部", score: 9.6, hours: 42, courses: 11 },
+    { id: 3, name: "山田 次郎", department: "マーケティング部", score: 9.4, hours: 38, courses: 10 }
+  ],
+  recentActivity: [
+    { id: 1, user: "鈴木 一郎", action: "コース完了", course: "顧客対応スキル向上", time: "2時間前" },
+    { id: 2, user: "高橋 美咲", action: "認定取得", course: "プレゼンテーション技法", time: "4時間前" },
+    { id: 3, user: "伊藤 健太", action: "学習開始", course: "リーダーシップ基礎", time: "6時間前" }
+  ]
+};
+
+function StatCard({ title, value, subtitle, icon: Icon, trend }) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-100 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="p-2 bg-blue-50 rounded-lg">
+          <Icon size={20} className="text-blue-600" />
+        </div>
+        {trend && (
+          <span className={`text-xs px-2 py-1 rounded-full ${
+            trend > 0 ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+          }`}>
+            {trend > 0 ? '+' : ''}{trend}%
+          </span>
+        )}
+      </div>
+      <h3 className="text-2xl font-bold text-gray-900 mb-1">{value}</h3>
+      <p className="text-sm text-gray-600">{title}</p>
+      {subtitle && <p className="text-xs text-gray-500 mt-1">{subtitle}</p>}
+    </div>
+  );
+}
+
+export default function AdminDashboard() {
+  const [activeTab, setActiveTab] = useState("overview");
+  const navigate = useNavigate();
+
+  const tabs = [
+    { id: "overview", label: "組織全体俯瞰", icon: BarChart3 },
+    { id: "departments", label: "部門別分析", icon: Users },
+    { id: "courses", label: "コース管理", icon: BookOpen }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <div className="bg-white border-b border-gray-200">
+        <div className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <button 
+                onClick={() => navigate("/setup")}
+                className="text-sm text-gray-500 hover:text-gray-700"
+              >
+                ← 戻る
+              </button>
+              <h1 className="text-xl font-semibold text-gray-900">管理職ダッシュボード</h1>
+            </div>
+            <div className="text-sm text-gray-500">
+              最終更新: {new Date().toLocaleDateString('ja-JP')} {new Date().toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' })}
+            </div>
+          </div>
+        </div>
+        
+        {/* Tab Navigation */}
+        <div className="flex border-b border-gray-200">
+          {tabs.map((tab) => {
+            const Icon = tab.icon;
+            return (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`flex items-center gap-2 px-6 py-3 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === tab.id
+                    ? "border-blue-500 text-blue-600"
+                    : "border-transparent text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                <Icon size={16} />
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="p-6">
+        {activeTab === "overview" && (
+          <div className="space-y-6">
+            {/* Stats Grid */}
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              <StatCard
+                title="総従業員数"
+                value={mockData.overallStats.totalEmployees}
+                subtitle="アクティブユーザー: 189名"
+                icon={Users}
+                trend={5}
+              />
+              <StatCard
+                title="全体完了率"
+                value={`${mockData.overallStats.completionRate}%`}
+                subtitle="前月比 +8%"
+                icon={TrendingUp}
+                trend={8}
+              />
+              <StatCard
+                title="平均スコア"
+                value={mockData.overallStats.averageScore}
+                subtitle="10点満点中"
+                icon={Star}
+                trend={3}
+              />
+              <StatCard
+                title="総学習時間"
+                value={`${mockData.overallStats.totalLearningHours}h`}
+                subtitle="今月累計"
+                icon={Clock}
+                trend={12}
+              />
+              <StatCard
+                title="コース完了数"
+                value={mockData.overallStats.coursesCompleted}
+                subtitle="今月累計"
+                icon={BookOpen}
+                trend={15}
+              />
+            </div>
+
+            {/* Charts and Tables */}
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              {/* Top Performers */}
+              <div className="bg-white rounded-lg border border-gray-100">
+                <div className="p-6 border-b border-gray-100">
+                  <h3 className="text-lg font-semibold text-gray-900">トップパフォーマー</h3>
+                </div>
+                <div className="p-6">
+                  <div className="space-y-4">
+                    {mockData.topPerformers.map((performer, index) => (
+                      <div key={performer.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                        <div className="flex items-center gap-3">
+                          <div className={`w-8 h-8 rounded-full flex items-center justify-center text-white font-bold ${
+                            index === 0 ? 'bg-yellow-500' : index === 1 ? 'bg-gray-400' : 'bg-orange-500'
+                          }`}>
+                            {index + 1}
+                          </div>
+                          <div>
+                            <p className="font-medium text-gray-900">{performer.name}</p>
+                            <p className="text-sm text-gray-600">{performer.department}</p>
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <p className="font-bold text-gray-900">{performer.score}</p>
+                          <p className="text-xs text-gray-500">{performer.hours}h • {performer.courses}コース</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              {/* Recent Activity */}
+              <div className="bg-white rounded-lg border border-gray-100">
+                <div className="p-6 border-b border-gray-100">
+                  <h3 className="text-lg font-semibold text-gray-900">最近のアクティビティ</h3>
+                </div>
+                <div className="p-6">
+                  <div className="space-y-4">
+                    {mockData.recentActivity.map((activity) => (
+                      <div key={activity.id} className="flex items-start gap-3">
+                        <div className="w-2 h-2 bg-blue-500 rounded-full mt-2"></div>
+                        <div className="flex-1">
+                          <p className="text-sm text-gray-900">
+                            <span className="font-medium">{activity.user}</span>が
+                            <span className="font-medium text-blue-600"> {activity.action}</span>
+                          </p>
+                          <p className="text-sm text-gray-600">{activity.course}</p>
+                          <p className="text-xs text-gray-500 mt-1">{activity.time}</p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {activeTab === "departments" && (
+          <div className="space-y-6">
+            <div className="bg-white rounded-lg border border-gray-100">
+              <div className="p-6 border-b border-gray-100">
+                <h3 className="text-lg font-semibold text-gray-900">部門別パフォーマンス</h3>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">部門名</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">メンバー数</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">完了率</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">平均スコア</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">アクティブユーザー</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">詳細</th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {mockData.departmentStats.map((dept) => (
+                      <tr key={dept.id} className="hover:bg-gray-50">
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{dept.name}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{dept.members}名</td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <div className="flex items-center">
+                            <div className="w-16 bg-gray-200 rounded-full h-2 mr-2">
+                              <div 
+                                className="bg-blue-600 h-2 rounded-full" 
+                                style={{ width: `${dept.completionRate}%` }}
+                              ></div>
+                            </div>
+                            <span className="text-sm text-gray-900">{dept.completionRate}%</span>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{dept.avgScore}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{dept.activeLearners}名</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                          <Link 
+                            to={`/admin/team?teamId=${dept.id}`}
+                            className="text-blue-600 hover:text-blue-900"
+                          >
+                            チーム詳細 →
+                          </Link>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {activeTab === "courses" && (
+          <div className="space-y-6">
+            <div className="bg-white rounded-lg border border-gray-100 p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-4">コース効果測定</h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {[
+                  { name: "顧客対応スキル向上", completions: 89, satisfaction: 4.7, roi: 125 },
+                  { name: "プレゼンテーション技法", completions: 67, satisfaction: 4.5, roi: 110 },
+                  { name: "リーダーシップ基礎", completions: 45, satisfaction: 4.8, roi: 140 },
+                  { name: "データ分析入門", completions: 34, satisfaction: 4.3, roi: 95 },
+                  { name: "チームマネジメント", completions: 28, satisfaction: 4.6, roi: 118 },
+                  { name: "デジタル変革基礎", completions: 52, satisfaction: 4.4, roi: 102 }
+                ].map((course, index) => (
+                  <div key={index} className="border border-gray-200 rounded-lg p-4">
+                    <h4 className="font-medium text-gray-900 mb-2">{course.name}</h4>
+                    <div className="space-y-2 text-sm text-gray-600">
+                      <div className="flex justify-between">
+                        <span>完了者数:</span>
+                        <span className="font-medium">{course.completions}名</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span>満足度:</span>
+                        <span className="font-medium">{course.satisfaction}/5.0</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span>ROI:</span>
+                        <span className={`font-medium ${course.roi >= 100 ? 'text-green-600' : 'text-red-600'}`}>
+                          {course.roi}%
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/components/AdminTeamDetail.jsx
+++ b/client/components/AdminTeamDetail.jsx
@@ -1,0 +1,356 @@
+import { useState, useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { User, Clock, BookOpen, TrendingUp, Award, Calendar } from "react-feather";
+
+// Mock team data
+const teamData = {
+  1: {
+    name: "営業部",
+    manager: "山田 部長",
+    members: [
+      { id: 1, name: "佐藤 花子", position: "主任", score: 9.6, hours: 42, courses: 11, progress: 85, lastActivity: "2時間前" },
+      { id: 2, name: "田中 一郎", position: "係長", score: 8.9, hours: 38, courses: 9, progress: 72, lastActivity: "1日前" },
+      { id: 3, name: "鈴木 美咲", position: "主任", score: 8.7, hours: 35, courses: 8, progress: 68, lastActivity: "3時間前" },
+      { id: 4, name: "高橋 健太", position: "一般", score: 8.2, hours: 28, courses: 6, progress: 58, lastActivity: "5時間前" },
+      { id: 5, name: "伊藤 恵", position: "一般", score: 7.9, hours: 25, courses: 5, progress: 45, lastActivity: "1日前" }
+    ]
+  },
+  2: {
+    name: "開発部",
+    manager: "鈴木 部長",
+    members: [
+      { id: 6, name: "田中 太郎", position: "リーダー", score: 9.8, hours: 45, courses: 12, progress: 95, lastActivity: "30分前" },
+      { id: 7, name: "山田 さくら", position: "シニア", score: 9.2, hours: 41, courses: 10, progress: 88, lastActivity: "1時間前" },
+      { id: 8, name: "松本 大輔", position: "シニア", score: 8.8, hours: 37, courses: 9, progress: 76, lastActivity: "2時間前" },
+      { id: 9, name: "中村 あやか", position: "一般", score: 8.4, hours: 33, courses: 7, progress: 64, lastActivity: "4時間前" }
+    ]
+  },
+  3: {
+    name: "マーケティング部",
+    manager: "田中 部長",
+    members: [
+      { id: 10, name: "山田 次郎", position: "主任", score: 9.4, hours: 38, courses: 10, progress: 82, lastActivity: "1時間前" },
+      { id: 11, name: "佐々木 美穂", position: "一般", score: 8.6, hours: 32, courses: 8, progress: 71, lastActivity: "3時間前" },
+      { id: 12, name: "渡辺 翔太", position: "一般", score: 8.1, hours: 29, courses: 6, progress: 59, lastActivity: "6時間前" }
+    ]
+  }
+};
+
+export default function AdminTeamDetail() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const teamId = searchParams.get('teamId');
+  const [team, setTeam] = useState(null);
+  const [selectedMember, setSelectedMember] = useState(null);
+
+  useEffect(() => {
+    if (teamId && teamData[teamId]) {
+      setTeam(teamData[teamId]);
+    }
+  }, [teamId]);
+
+  if (!team) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">チームが見つかりません</h2>
+          <button 
+            onClick={() => navigate("/admin")}
+            className="text-blue-600 hover:text-blue-700"
+          >
+            ← ダッシュボードに戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const teamAverage = {
+    score: (team.members.reduce((sum, m) => sum + m.score, 0) / team.members.length).toFixed(1),
+    hours: Math.round(team.members.reduce((sum, m) => sum + m.hours, 0) / team.members.length),
+    courses: Math.round(team.members.reduce((sum, m) => sum + m.courses, 0) / team.members.length),
+    progress: Math.round(team.members.reduce((sum, m) => sum + m.progress, 0) / team.members.length)
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <div className="bg-white border-b border-gray-200">
+        <div className="px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <button 
+                onClick={() => navigate("/admin")}
+                className="text-sm text-gray-500 hover:text-gray-700"
+              >
+                ← ダッシュボード
+              </button>
+              <div>
+                <h1 className="text-xl font-semibold text-gray-900">{team.name} チーム詳細</h1>
+                <p className="text-sm text-gray-600">管理者: {team.manager}</p>
+              </div>
+            </div>
+            <div className="text-sm text-gray-500">
+              メンバー数: {team.members.length}名
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-6">
+        {/* Team Summary Stats */}
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+          <div className="bg-white rounded-lg border border-gray-100 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 bg-blue-50 rounded-lg">
+                <TrendingUp size={20} className="text-blue-600" />
+              </div>
+              <h3 className="font-medium text-gray-900">平均スコア</h3>
+            </div>
+            <p className="text-2xl font-bold text-gray-900">{teamAverage.score}</p>
+            <p className="text-sm text-gray-600">10点満点中</p>
+          </div>
+          
+          <div className="bg-white rounded-lg border border-gray-100 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 bg-green-50 rounded-lg">
+                <Clock size={20} className="text-green-600" />
+              </div>
+              <h3 className="font-medium text-gray-900">平均学習時間</h3>
+            </div>
+            <p className="text-2xl font-bold text-gray-900">{teamAverage.hours}h</p>
+            <p className="text-sm text-gray-600">今月</p>
+          </div>
+          
+          <div className="bg-white rounded-lg border border-gray-100 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 bg-purple-50 rounded-lg">
+                <BookOpen size={20} className="text-purple-600" />
+              </div>
+              <h3 className="font-medium text-gray-900">平均コース数</h3>
+            </div>
+            <p className="text-2xl font-bold text-gray-900">{teamAverage.courses}</p>
+            <p className="text-sm text-gray-600">完了済み</p>
+          </div>
+          
+          <div className="bg-white rounded-lg border border-gray-100 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 bg-orange-50 rounded-lg">
+                <Award size={20} className="text-orange-600" />
+              </div>
+              <h3 className="font-medium text-gray-900">平均進捗率</h3>
+            </div>
+            <p className="text-2xl font-bold text-gray-900">{teamAverage.progress}%</p>
+            <p className="text-sm text-gray-600">現在の進捗</p>
+          </div>
+        </div>
+
+        {/* Member List */}
+        <div className="bg-white rounded-lg border border-gray-100">
+          <div className="p-6 border-b border-gray-100">
+            <h3 className="text-lg font-semibold text-gray-900">メンバー一覧</h3>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">名前</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">役職</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">スコア</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">学習時間</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">完了コース</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">進捗</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">最終活動</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">詳細</th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {team.members.map((member) => (
+                  <tr key={member.id} className="hover:bg-gray-50">
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="flex items-center">
+                        <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center mr-3">
+                          <User size={16} className="text-gray-600" />
+                        </div>
+                        <div className="text-sm font-medium text-gray-900">{member.name}</div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{member.position}</td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                        member.score >= 9 ? 'bg-green-100 text-green-800' :
+                        member.score >= 8 ? 'bg-blue-100 text-blue-800' :
+                        'bg-yellow-100 text-yellow-800'
+                      }`}>
+                        {member.score}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{member.hours}h</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{member.courses}</td>
+                    <td className="px-6 py-4 whitespace-nowrap">
+                      <div className="flex items-center">
+                        <div className="w-16 bg-gray-200 rounded-full h-2 mr-2">
+                          <div 
+                            className={`h-2 rounded-full ${
+                              member.progress >= 80 ? 'bg-green-600' :
+                              member.progress >= 60 ? 'bg-blue-600' :
+                              'bg-yellow-600'
+                            }`}
+                            style={{ width: `${member.progress}%` }}
+                          ></div>
+                        </div>
+                        <span className="text-sm text-gray-900">{member.progress}%</span>
+                      </div>
+                    </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{member.lastActivity}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                      <button
+                        onClick={() => setSelectedMember(member)}
+                        className="text-blue-600 hover:text-blue-900"
+                      >
+                        詳細表示
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Action Items Section */}
+        <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="bg-white rounded-lg border border-gray-100">
+            <div className="p-6 border-b border-gray-100">
+              <h3 className="text-lg font-semibold text-gray-900">要注意メンバー</h3>
+            </div>
+            <div className="p-6">
+              {team.members.filter(m => m.progress < 60 || m.score < 8).map((member) => (
+                <div key={member.id} className="flex items-center justify-between p-3 bg-red-50 rounded-lg mb-3 last:mb-0">
+                  <div>
+                    <p className="font-medium text-gray-900">{member.name}</p>
+                    <p className="text-sm text-gray-600">
+                      {member.progress < 60 && `進捗率低下 (${member.progress}%)`}
+                      {member.progress < 60 && member.score < 8 && " • "}
+                      {member.score < 8 && `スコア改善必要 (${member.score})`}
+                    </p>
+                  </div>
+                  <span className="text-xs bg-red-100 text-red-700 px-2 py-1 rounded-full">
+                    要サポート
+                  </span>
+                </div>
+              ))}
+              {team.members.filter(m => m.progress >= 60 && m.score >= 8).length === team.members.length && (
+                <div className="text-center py-4 text-gray-500">
+                  <Award size={24} className="mx-auto mb-2 text-green-500" />
+                  <p>全メンバーが良好なパフォーマンスです</p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="bg-white rounded-lg border border-gray-100">
+            <div className="p-6 border-b border-gray-100">
+              <h3 className="text-lg font-semibold text-gray-900">推奨アクション</h3>
+            </div>
+            <div className="p-6">
+              <div className="space-y-3">
+                <div className="flex items-start gap-3">
+                  <Calendar size={16} className="text-blue-600 mt-1" />
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">定期1on1面談の実施</p>
+                    <p className="text-xs text-gray-600">進捗の遅いメンバーとの個別面談をスケジュール</p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <BookOpen size={16} className="text-green-600 mt-1" />
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">追加学習コンテンツの提供</p>
+                    <p className="text-xs text-gray-600">基礎スキル向上のための補助教材を案内</p>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <Award size={16} className="text-purple-600 mt-1" />
+                  <div>
+                    <p className="text-sm font-medium text-gray-900">優秀者による指導体制</p>
+                    <p className="text-xs text-gray-600">高スコアメンバーをメンターとして活用</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Member Detail Modal */}
+      {selectedMember && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-lg max-w-md w-full">
+            <div className="p-6 border-b border-gray-100">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-gray-900">{selectedMember.name} 詳細</h3>
+                <button
+                  onClick={() => setSelectedMember(null)}
+                  className="text-gray-400 hover:text-gray-600"
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+            <div className="p-6">
+              <div className="space-y-4">
+                <div className="flex justify-between">
+                  <span className="text-gray-600">役職:</span>
+                  <span className="font-medium">{selectedMember.position}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-600">現在のスコア:</span>
+                  <span className="font-medium">{selectedMember.score}/10</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-600">学習時間:</span>
+                  <span className="font-medium">{selectedMember.hours}時間</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-600">完了コース:</span>
+                  <span className="font-medium">{selectedMember.courses}コース</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-600">進捗率:</span>
+                  <span className="font-medium">{selectedMember.progress}%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-600">最終活動:</span>
+                  <span className="font-medium">{selectedMember.lastActivity}</span>
+                </div>
+              </div>
+              <div className="mt-6 pt-6 border-t border-gray-100">
+                <h4 className="font-medium text-gray-900 mb-3">推奨アクション</h4>
+                <div className="space-y-2 text-sm">
+                  {selectedMember.score < 8 && (
+                    <div className="flex items-center gap-2 text-amber-700">
+                      <span className="w-2 h-2 bg-amber-500 rounded-full"></span>
+                      スキル向上のための追加トレーニングが推奨されます
+                    </div>
+                  )}
+                  {selectedMember.progress < 60 && (
+                    <div className="flex items-center gap-2 text-red-700">
+                      <span className="w-2 h-2 bg-red-500 rounded-full"></span>
+                      学習進捗について個別面談が必要です
+                    </div>
+                  )}
+                  {selectedMember.score >= 9 && selectedMember.progress >= 80 && (
+                    <div className="flex items-center gap-2 text-green-700">
+                      <span className="w-2 h-2 bg-green-500 rounded-full"></span>
+                      優秀なパフォーマンス。メンター候補として検討
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -8,6 +8,8 @@ import ChatInterface from "./ChatInterface";
 import SessionControls from "./SessionControls";
 import ToolPanel from "./ToolPanel";
 import LoginScreen from "./LoginScreen";
+import AdminDashboard from "./AdminDashboard";
+import AdminTeamDetail from "./AdminTeamDetail";
 import { checkAuthStatus, logout } from "../utils/auth";
 
 export default function App() {
@@ -411,6 +413,7 @@ export default function App() {
                 setSceneSettings={setSceneSettings}
                 startSession={startSession}
                 VOICE_OPTIONS={VOICE_OPTIONS}
+                currentUser={currentUser}
               />
             } 
           />
@@ -433,6 +436,26 @@ export default function App() {
                 onStopSession={handleStopSession}
               />
             } 
+          />
+          <Route 
+            path="/admin" 
+            element={
+              currentUser === "admin" ? (
+                <AdminDashboard />
+              ) : (
+                <Navigate to="/setup" replace />
+              )
+            }
+          />
+          <Route 
+            path="/admin/team" 
+            element={
+              currentUser === "admin" ? (
+                <AdminTeamDetail />
+              ) : (
+                <Navigate to="/setup" replace />
+              )
+            }
           />
         </Routes>
       </div>

--- a/client/components/SetupScreen.jsx
+++ b/client/components/SetupScreen.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { ChevronDown, ChevronUp, Play, Settings, User, MapPin } from "react-feather";
+import { ChevronDown, ChevronUp, Play, Settings, User, MapPin, BarChart3 } from "react-feather";
+import { Link } from "react-router-dom";
 import Button from "./Button";
 import groqService from "../services/groq";
 import PromptModal from "./PromptModal";
@@ -47,7 +48,8 @@ export default function SetupScreen({
   sceneSettings,
   setSceneSettings,
   startSession,
-  VOICE_OPTIONS 
+  VOICE_OPTIONS,
+  currentUser
 }) {
   const [isStarting, setIsStarting] = useState(false);
   const [showPromptModal, setShowPromptModal] = useState(false);
@@ -227,7 +229,19 @@ export default function SetupScreen({
     <div className="flex-1 overflow-y-auto p-6 bg-white">
       <div className="max-w-lg mx-auto space-y-6">
         {/* Header - Clean and minimal */}
-        <div className="text-center py-8">
+        <div className="text-center py-8 relative">
+          {/* Admin Dashboard Link - Top Right */}
+          {currentUser === "admin" && (
+            <div className="absolute top-0 right-0">
+              <Link
+                to="/admin"
+                className="flex items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
+              >
+                <BarChart3 size={16} />
+                管理職ダッシュボード
+              </Link>
+            </div>
+          )}
           <h1 className="text-2xl font-semibold text-gray-900 mb-2">AIロールプレイ</h1>
         </div>
 

--- a/client/components/SetupScreen.jsx
+++ b/client/components/SetupScreen.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronDown, ChevronUp, Play, Settings, User, MapPin, BarChart3 } from "react-feather";
+import { ChevronDown, ChevronUp, Play, Settings, User, MapPin, BarChart } from "react-feather";
 import { Link } from "react-router-dom";
 import Button from "./Button";
 import groqService from "../services/groq";
@@ -237,7 +237,7 @@ export default function SetupScreen({
                 to="/admin"
                 className="flex items-center gap-2 px-3 py-2 text-sm text-gray-600 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors"
               >
-                <BarChart3 size={16} />
+                <BarChart size={16} />
                 管理職ダッシュボード
               </Link>
             </div>


### PR DESCRIPTION
Resolves #114

## Summary
- Added admin management dashboard at `/admin`
- Added team detail view at `/admin/team?teamId=X`
- Admin-only navigation link in SetupScreen top-right
- Comprehensive dashboard with 3 main views: 組織全体俯瞰, 部門別分析, コース管理
- Mock data with realistic enterprise metrics and insights
- Team member performance tracking and recommendations

Generated with [Claude Code](https://claude.ai/code)