### PR TITLE
fix: モバイルデバイスでの縦スクロールを有効化

### DIFF
--- a/client/base.css
+++ b/client/base.css
@@ -43,7 +43,8 @@ body {
   height: 100vh;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 /* Fix mobile viewport height issues */

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -367,7 +367,7 @@ export default function App() {
   }
 
   return (
-    <div className="h-screen bg-white flex flex-col overflow-hidden">
+    <div className="h-screen bg-white flex flex-col overflow-x-hidden overflow-y-auto">
       {/* Header - Apple-inspired minimal design */}
       <nav className="bg-white border-b border-gray-100 px-4 py-3 flex-shrink-0">
         <div className="flex items-center justify-between">

--- a/client/components/ChatInterface.jsx
+++ b/client/components/ChatInterface.jsx
@@ -23,7 +23,7 @@ export default function ChatInterface({
   }
 
   return (
-    <div className="flex-1 flex flex-col h-full bg-white">
+    <div className="flex-1 flex flex-col h-full bg-white overflow-x-hidden overflow-y-auto">
       {/* Main content area */}
       <div className="flex-1 flex flex-col items-center justify-center p-6 space-y-12">
         

--- a/client/components/SetupScreen.jsx
+++ b/client/components/SetupScreen.jsx
@@ -226,7 +226,7 @@ export default function SetupScreen({
 
 
   return (
-    <div className="flex-1 overflow-y-auto p-6 bg-white">
+    <div className="flex-1 overflow-x-hidden overflow-y-auto p-6 bg-white">
       <div className="max-w-lg mx-auto space-y-6">
         {/* Header - Clean and minimal */}
         <div className="text-center py-8 relative">


### PR DESCRIPTION
Issue #119 を修正

### 問題
スマートフォンで縦スクロールが無効になっていた

### 修正内容
- `client/base.css` - `#root`要素の`overflow: hidden`を`overflow-x: hidden; overflow-y: auto`に変更
- `client/components/App.jsx` - `overflow-hidden`クラスを`overflow-x-hidden overflow-y-auto`に変更
- 其他のコンポーネントでも同様に調整

これによりモバイルでの縦スクロールが正常に機能します。

Generated with [Claude Code](https://claude.ai/code)