### PR TITLE
feat: make member and department names clickable in dashboard

### DIFF
--- a/client/components/AdminDashboard.jsx
+++ b/client/components/AdminDashboard.jsx
@@ -167,7 +167,12 @@ export default function AdminDashboard() {
                             {index + 1}
                           </div>
                           <div>
-                            <p className="font-medium text-gray-900">{performer.name}</p>
+                            <Link 
+                              to={`/admin/employee?employeeId=${performer.id}`}
+                              className="font-medium text-gray-900 hover:text-blue-600 transition-colors"
+                            >
+                              {performer.name}
+                            </Link>
                             <p className="text-sm text-gray-600">{performer.department}</p>
                           </div>
                         </div>
@@ -193,7 +198,12 @@ export default function AdminDashboard() {
                         <div className="w-2 h-2 bg-blue-500 rounded-full mt-2"></div>
                         <div className="flex-1">
                           <p className="text-sm text-gray-900">
-                            <span className="font-medium">{activity.user}</span>が
+                            <Link 
+                              to={`/admin/employee?employeeId=${activity.id}`}
+                              className="font-medium hover:text-blue-600 transition-colors"
+                            >
+                              {activity.user}
+                            </Link>が
                             <span className="font-medium text-blue-600"> {activity.action}</span>
                           </p>
                           <p className="text-sm text-gray-600">{activity.course}</p>
@@ -229,7 +239,14 @@ export default function AdminDashboard() {
                   <tbody className="bg-white divide-y divide-gray-200">
                     {mockData.departmentStats.map((dept) => (
                       <tr key={dept.id} className="hover:bg-gray-50">
-                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{dept.name}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                          <Link 
+                            to={`/admin/team?teamId=${dept.id}`}
+                            className="text-gray-900 hover:text-blue-600 transition-colors"
+                          >
+                            {dept.name}
+                          </Link>
+                        </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{dept.members}名</td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="flex items-center">

--- a/client/components/AdminTeamDetail.jsx
+++ b/client/components/AdminTeamDetail.jsx
@@ -172,7 +172,12 @@ export default function AdminTeamDetail() {
                         <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center mr-3">
                           <User size={16} className="text-gray-600" />
                         </div>
-                        <div className="text-sm font-medium text-gray-900">{member.name}</div>
+                        <Link 
+                          to={`/admin/employee?employeeId=${member.id}&teamId=${teamId}`}
+                          className="text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors"
+                        >
+                          {member.name}
+                        </Link>
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{member.position}</td>


### PR DESCRIPTION
**Summary**

- Make member and department names clickable throughout the dashboard for improved navigation UX
- Add hover effects with blue color transitions for visual feedback
- Maintain existing functionality while adding intuitive name-based navigation

**Changes**

- AdminDashboard.jsx: Made names clickable in Top Performers, Recent Activity, and Departments sections
- AdminTeamDetail.jsx: Made member names clickable in the team member table
- Added consistent hover styling across all clickable names

**Testing**

- Build passes successfully
- All navigation routes properly configured
- Visual feedback working correctly

Fixes #122

Generated with [Claude Code](https://claude.ai/code)