### PR TITLE
feat: setupScreenにCSタブを追加、プリセットを3タブに再編成

### DIFF
--- a/client/components/PresetSelector.tsx
+++ b/client/components/PresetSelector.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Zap, ChevronRight, Edit3, Settings, X, Volume2 } from "react-feather";
-import { getPresetsByCategory, getPresetById, getTopLevelPresets } from "../data/presets";
+import { getPresetsByCategory, getPresetById, getTopLevelPresets, getPresetsByTab } from "../data/presets";
 import Button from "./Button";
 import type { PresetSelectorProps, PresetData, VoiceOption } from "../types";
 
@@ -8,12 +8,15 @@ export default function PresetSelector({
   onPresetSelect, 
   onDirectStart,
   selectedPresetId,
-  setSelectedPresetId 
-}: PresetSelectorProps) {
+  setSelectedPresetId,
+  activeTab
+}: PresetSelectorProps & { activeTab?: string }) {
   const [showAdvanced, setShowAdvanced] = useState<boolean>(false);
   const [showSettingsModal, setShowSettingsModal] = useState<boolean>(false);
   const [selectedPresetForSettings, setSelectedPresetForSettings] = useState<PresetData | null>(null);
-  const topLevelPresets = getTopLevelPresets();
+  
+  // Get presets based on active tab or fall back to top level presets
+  const currentPresets = activeTab ? getPresetsByTab(activeTab) : getTopLevelPresets();
   const categorizedPresets = getPresetsByCategory();
   const categories = Object.keys(categorizedPresets).filter(category => category !== "トップ");
 
@@ -163,9 +166,9 @@ export default function PresetSelector({
       <>
         <div className="space-y-4">
 
-          {/* トップレベルプリセット一覧 */}
+          {/* 現在のタブのプリセット一覧 */}
           <div className="space-y-3">
-            {topLevelPresets.map((preset) => (
+            {currentPresets.map((preset) => (
               <div key={preset.id} className="space-y-2">
                 <div className={`relative w-full p-4 rounded-xl border-2 transition-all duration-200 ${
                   selectedPresetId === preset.id

--- a/client/components/SetupScreen.tsx
+++ b/client/components/SetupScreen.tsx
@@ -6,6 +6,7 @@ import groqService from "../services/groq";
 import PromptModal from "./PromptModal";
 import { selectVoiceByRules } from "../utils/voiceSelection";
 import PresetSelector from "./PresetSelector";
+import { getPresetsByTab } from "../data/presets";
 import type { 
   SetupScreenProps, 
   ViewMode, 
@@ -68,6 +69,7 @@ export default function SetupScreen({
   const [showPromptModal, setShowPromptModal] = useState<boolean>(false);
   const [generatedPrompt, setGeneratedPrompt] = useState<string>("");
   const [viewMode, setViewMode] = useState<ViewMode>("preset");
+  const [activeTab, setActiveTab] = useState<string>("デモ");
   const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
   const immersionLevel: ImmersionLevel = "high"; // Always set to high as requested
 
@@ -282,6 +284,42 @@ export default function SetupScreen({
           </button>
         </div>
 
+        {/* Preset Tab Selection */}
+        {viewMode === "preset" && (
+          <div className="bg-gray-100 rounded-lg p-1 flex">
+            <button
+              onClick={() => setActiveTab("デモ")}
+              className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-all ${
+                activeTab === "デモ"
+                  ? "bg-white text-gray-900 shadow-sm"
+                  : "text-gray-600 hover:text-gray-900"
+              }`}
+            >
+              デモ
+            </button>
+            <button
+              onClick={() => setActiveTab("CS")}
+              className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-all ${
+                activeTab === "CS"
+                  ? "bg-white text-gray-900 shadow-sm"
+                  : "text-gray-600 hover:text-gray-900"
+              }`}
+            >
+              CS
+            </button>
+            <button
+              onClick={() => setActiveTab("プリセット")}
+              className={`flex-1 py-2 px-3 rounded-md text-sm font-medium transition-all ${
+                activeTab === "プリセット"
+                  ? "bg-white text-gray-900 shadow-sm"
+                  : "text-gray-600 hover:text-gray-900"
+              }`}
+            >
+              プリセット
+            </button>
+          </div>
+        )}
+
         {/* Content based on view mode */}
         {viewMode === "preset" ? (
           <PresetSelector
@@ -290,6 +328,7 @@ export default function SetupScreen({
             onDirectStart={handleDirectStart}
             selectedPresetId={selectedPresetId || ""}
             setSelectedPresetId={setSelectedPresetId}
+            activeTab={activeTab}
           />
         ) : (
           <>

--- a/client/components/SetupScreen.tsx
+++ b/client/components/SetupScreen.tsx
@@ -6,7 +6,6 @@ import groqService from "../services/groq";
 import PromptModal from "./PromptModal";
 import { selectVoiceByRules } from "../utils/voiceSelection";
 import PresetSelector from "./PresetSelector";
-import { getPresetsByTab } from "../data/presets";
 import type { 
   SetupScreenProps, 
   ViewMode, 

--- a/client/data/presets.ts
+++ b/client/data/presets.ts
@@ -4,7 +4,7 @@ import type { PresetData, PresetsByCategory } from "../types";
 export const presets: Record<string, PresetData> = {
   "real_estate_asset_hearing": {
     id: "real_estate_asset_hearing",
-    category: "トップ",
+    category: "デモ",
     name: "不動産営業の資産背景ヒアリング",
     description: "顧客の資産背景を詳しくヒアリングし、最適な物件提案につなげる営業",
     icon: "🏡",
@@ -122,7 +122,7 @@ export const presets: Record<string, PresetData> = {
   
   "customer_support_complaint_training": {
     id: "customer_support_complaint_training",
-    category: "トップ",
+    category: "デモ",
     name: "カスタマーサポートのクレーム対応強化",
     description: "難しいクレーム対応を通じて、顧客満足度向上とスキルアップを図る",
     icon: "📞",
@@ -182,7 +182,7 @@ export const presets: Record<string, PresetData> = {
   
   "water_server_sales_training": {
     id: "water_server_sales_training",
-    category: "トップ",
+    category: "デモ",
     name: "育毛剤の解約引き止め",
     description: "育毛剤の定期購入の解約を引き止めるロールプレイ",
     icon: "🫷",
@@ -560,8 +560,8 @@ export const presets: Record<string, PresetData> = {
   // 5つの追加プリセット（既存の複製）
   "real_estate_asset_hearing_2": {
     id: "real_estate_asset_hearing_2",
-    category: "トップ",
-    name: "不動産営業の資産背景ヒアリング（複製1）",
+    category: "CS",
+    name: "複製の1件目",
     description: "顧客の資産背景を詳しくヒアリングし、最適な物件提案につなげる営業",
     icon: "🏡",
     purpose: "顧客の資産状況、投資経験、購入動機を深くヒアリングし、信頼関係を築きながら最適な不動産提案を行う",
@@ -678,8 +678,8 @@ export const presets: Record<string, PresetData> = {
 
   "customer_support_complaint_training_2": {
     id: "customer_support_complaint_training_2",
-    category: "トップ",
-    name: "カスタマーサポートのクレーム対応強化（複製1）",
+    category: "CS",
+    name: "複製の2件目",
     description: "難しいクレーム対応を通じて、顧客満足度向上とスキルアップを図る",
     icon: "📞",
     purpose: "クレーム対応のスキル向上を図り、怒っている顧客を満足させる対応力を身につける",
@@ -738,8 +738,8 @@ export const presets: Record<string, PresetData> = {
 
   "water_server_sales_training_2": {
     id: "water_server_sales_training_2",
-    category: "トップ",
-    name: "育毛剤の解約引き止め（複製1）",
+    category: "CS",
+    name: "複製の3件目",
     description: "育毛剤の定期購入の解約を引き止めるロールプレイ",
     icon: "🫷",
     purpose: "ウォーターサーバー営業の商品説明と質疑応答の練習",
@@ -828,8 +828,8 @@ export const presets: Record<string, PresetData> = {
 
   "real_estate_asset_hearing_3": {
     id: "real_estate_asset_hearing_3",
-    category: "トップ",
-    name: "不動産営業の資産背景ヒアリング（複製2）",
+    category: "CS",
+    name: "複製の4件目",
     description: "顧客の資産背景を詳しくヒアリングし、最適な物件提案につなげる営業",
     icon: "🏡",
     purpose: "顧客の資産状況、投資経験、購入動機を深くヒアリングし、信頼関係を築きながら最適な不動産提案を行う",
@@ -946,8 +946,8 @@ export const presets: Record<string, PresetData> = {
 
   "customer_support_complaint_training_3": {
     id: "customer_support_complaint_training_3",
-    category: "トップ",
-    name: "カスタマーサポートのクレーム対応強化（複製2）",
+    category: "CS",
+    name: "複製の5件目",
     description: "難しいクレーム対応を通じて、顧客満足度向上とスキルアップを図る",
     icon: "📞",
     purpose: "クレーム対応のスキル向上を図り、怒っている顧客を満足させる対応力を身につける",
@@ -1031,4 +1031,9 @@ export const getAllCategories = (): string[] => {
 // トップレベルプリセットの取得（階層なし表示用）
 export const getTopLevelPresets = (): PresetData[] => {
   return Object.values(presets).filter(preset => preset.category === "トップ");
+};
+
+// カテゴリ別プリセット取得（新しいタブ用）
+export const getPresetsByTab = (tabName: string): PresetData[] => {
+  return Object.values(presets).filter(preset => preset.category === tabName);
 };


### PR DESCRIPTION
- プリセット表示を「デモ」「CS」「プリセット」の3タブに変更
- 既存プリセット3件を「デモ」カテゴリに移動
- 複製プリセット5件を「CS」カテゴリに移動し「複製の1〜5件目」に名前変更
- PresetSelectorとSetupScreenをタブ切り替え対応に更新

🤖 Generated with [Claude Code](https://claude.ai/code)