### PR TITLE
feat: add AI speaking indicator popup

### DIFF
--- a/client/components/App.tsx
+++ b/client/components/App.tsx
@@ -337,19 +337,23 @@ export default function App() {
           event.timestamp = new Date().toLocaleTimeString();
         }
 
-        // Update UI states based on events
+        // Update UI states based on events - WebRTC mode
         if (event.type === 'input_audio_buffer.speech_started') {
           setIsListening(true);
           setIsSpeaking(false);
         } else if (event.type === 'input_audio_buffer.speech_stopped') {
           setIsListening(false);
-        } else if (event.type === 'response.audio.delta' || event.type === 'response.audio_transcript.delta') {
+        } else if (event.type === 'output_audio_buffer.started') {
+          // WebRTC: Server starts audio buffer output - AI begins speaking
           setIsSpeaking(true);
           setIsListening(false);
-        } else if (event.type === 'response.audio.done' || event.type === 'response.audio_transcript.done') {
-          // AI finished speaking - use specific audio completion events
+        } else if (event.type === 'output_audio_buffer.stopped') {
+          // WebRTC: Server audio buffer empty - AI finished speaking
           setIsSpeaking(false);
           setIsListening(false);
+        } else if (event.type === 'output_audio_buffer.cleared') {
+          // WebRTC: Audio output interrupted (user spoke or manual stop)
+          setIsSpeaking(false);
         } else if (event.type === 'response.done') {
           // Response completed - ensure states are clean
           setIsListening(false);

--- a/client/components/ChatInterface.tsx
+++ b/client/components/ChatInterface.tsx
@@ -5,6 +5,7 @@ export default function ChatInterface({
   isSessionActive,
   isMuted = false,
   toggleMute,
+  isSpeaking = false,
   personaSettings = {
     age: "",
     gender: "",
@@ -100,6 +101,16 @@ export default function ChatInterface({
           <div className="fixed top-20 left-1/2 transform -translate-x-1/2 bg-red-500 text-white px-4 py-2 rounded-lg z-20 flex items-center gap-2">
             <MicOff size={16} />
             <span className="text-sm font-medium">マイクミュート中</span>
+          </div>
+        )}
+
+        {/* AI Speaking indicator overlay */}
+        {isSessionActive && isSpeaking && (
+          <div className={`fixed left-1/2 transform -translate-x-1/2 bg-blue-500 text-white px-4 py-2 rounded-lg z-20 flex items-center gap-2 animate-pulse ${
+            isMuted ? 'top-32' : 'top-20'
+          }`}>
+            <div className="w-3 h-3 bg-white rounded-full animate-ping"></div>
+            <span className="text-sm font-medium">AIが発話中</span>
           </div>
         )}
       </div>


### PR DESCRIPTION
Add 'AIが発話中' popup when AI is speaking

Features:
- Uses OpenAI Realtime API events for accurate detection
- Smart positioning to avoid conflicts with mute indicator
- Includes animated ping dot for visual attention
- Clean integration with existing UI patterns

Resolves #157

Generated with [Claude Code](https://claude.ai/code)